### PR TITLE
Add verify_server_cert support to MySQL source.

### DIFF
--- a/ml_metadata/metadata_store/mysql_metadata_source.cc
+++ b/ml_metadata/metadata_store/mysql_metadata_source.cc
@@ -120,6 +120,8 @@ Status MySqlMetadataSource::ConnectImpl() {
                   ssl.ca().empty() ? nullptr : ssl.ca().c_str(),
                   ssl.capath().empty() ? nullptr : ssl.capath().c_str(),
                   ssl.cipher().empty() ? nullptr : ssl.cipher().c_str());
+    my_bool verify_server_cert = ssl.verify_server_cert() ? 1 : 0;
+    mysql_options(db_, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify_server_cert);
   }
 
   // Connect to the MYSQL server.

--- a/ml_metadata/proto/metadata_store.proto
+++ b/ml_metadata/proto/metadata_store.proto
@@ -380,6 +380,9 @@ message MySQLDatabaseConfig {
     optional string capath = 4;
     // The list of permissible ciphers for SSL encryption.
     optional string cipher = 5;
+    // If set, enable verification of the server certificate against the host
+    // name used when connecting to the server.
+    optional bool verify_server_cert = 6;
   }
   // If the field is set, the ssl options are set in mysql_options before
   // establishing a connection. It is ignored if the mysql server does not


### PR DESCRIPTION
This pr continues #20 and adds an option to set MYSQL_OPT_SSL_VERIFY_SERVER_CERT.

I did some test with my database and it works; Without openssl 1.0.2 it won't work in some cases due to https://jira.mariadb.org/browse/MDEV-10594 (and its corresponding https://jira.mariadb.org/browse/CONC-250), but this option should still be useful to many.

The docker image this repo currently uses (manylinux2010) seems to have openssl 1.0.1e - any chance we can get openssl 1.0.2 there?