### PR TITLE
Document required imports in the Getting started guide

### DIFF
--- a/g3doc/get_started.md
+++ b/g3doc/get_started.md
@@ -48,6 +48,15 @@ following list provides a non-exhaustive overview of some of the major benefits.
     changelist used for a workflow run; group the lineage by experiments; manage
     artifacts by projects.
 
+## Imports
+
+Before setting up the datastore, you will need to set up imports.
+
+```python
+from ml_metadata import metadata_store
+from ml_metadata.proto import metadata_store_pb2
+```
+
 ## Metadata Storage Backends and Store Connection Configuration
 
 The MetadataStore object receives a connection configuration that corresponds to


### PR DESCRIPTION
So that it shows up on https://github.com/google/ml-metadata/blob/master/g3doc/get_started.md and hopefully https://www.tensorflow.org/tfx/guide/mlmd too.