### PR TITLE
Adds ReadTypes workload for mlmd_bench.

### DIFF
--- a/ml_metadata/tools/mlmd_bench/BUILD
+++ b/ml_metadata/tools/mlmd_bench/BUILD
@@ -172,6 +172,43 @@ ml_metadata_cc_test(
 )
 
 cc_library(
+    name = "read_types_workload",
+    srcs = ["read_types_workload.cc"],
+    hdrs = ["read_types_workload.h"],
+    deps = [
+        ":workload",
+        ":util",
+        "@com_google_absl//absl/time",
+        "//ml_metadata/metadata_store:metadata_store",
+        "//ml_metadata/metadata_store:types",
+        "//ml_metadata/proto:metadata_store_proto",
+        "//ml_metadata/proto:metadata_store_service_proto",
+        "//ml_metadata/tools/mlmd_bench/proto:mlmd_bench_proto",
+        "@org_tensorflow//tensorflow/core:lib",
+    ],
+)
+
+ml_metadata_cc_test(
+    name = "read_types_workload_test",
+    size = "small",
+    srcs = ["read_types_workload_test.cc"],
+    deps = [
+        ":read_types_workload",
+        ":util",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/memory",
+        "//ml_metadata/metadata_store",
+        "//ml_metadata/metadata_store:metadata_store_factory",
+        "//ml_metadata/metadata_store:test_util",
+        "//ml_metadata/metadata_store:types",
+        "//ml_metadata/proto:metadata_store_proto",
+        "//ml_metadata/proto:metadata_store_service_proto",
+        "//ml_metadata/tools/mlmd_bench/proto:mlmd_bench_proto",
+        "@org_tensorflow//tensorflow/core:test",
+    ],
+)
+
+cc_library(
     name = "stats",
     srcs = ["stats.cc"],
     hdrs = ["stats.h"],
@@ -204,6 +241,7 @@ cc_library(
         ":fill_events_workload",
         ":fill_nodes_workload",
         ":fill_types_workload",
+        ":read_types_workload",
         ":workload",
         "@com_google_absl//absl/memory",
         "//ml_metadata/metadata_store:types",

--- a/ml_metadata/tools/mlmd_bench/benchmark.cc
+++ b/ml_metadata/tools/mlmd_bench/benchmark.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "ml_metadata/tools/mlmd_bench/fill_nodes_workload.h"
 #include "ml_metadata/tools/mlmd_bench/fill_types_workload.h"
 #include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/read_types_workload.h"
 #include "ml_metadata/tools/mlmd_bench/workload.h"
 
 namespace ml_metadata {
@@ -51,6 +52,12 @@ std::unique_ptr<WorkloadBase> CreateWorkload(
       return absl::make_unique<FillEvents>(
           FillEvents(workload_config.fill_events_config(),
                      workload_config.num_operations()));
+      break;
+    }
+    case WorkloadConfig::kReadTypesConfig: {
+      workload = absl::make_unique<ReadTypes>(
+          ReadTypes(workload_config.read_types_config(),
+                    workload_config.num_operations()));
       break;
     }
     default:

--- a/ml_metadata/tools/mlmd_bench/benchmark.cc
+++ b/ml_metadata/tools/mlmd_bench/benchmark.cc
@@ -52,13 +52,11 @@ std::unique_ptr<WorkloadBase> CreateWorkload(
       return absl::make_unique<FillEvents>(
           FillEvents(workload_config.fill_events_config(),
                      workload_config.num_operations()));
-      break;
     }
     case WorkloadConfig::kReadTypesConfig: {
-      workload = absl::make_unique<ReadTypes>(
+      return absl::make_unique<ReadTypes>(
           ReadTypes(workload_config.read_types_config(),
                     workload_config.num_operations()));
-      break;
     }
     default:
       LOG(FATAL) << "Cannot find corresponding workload!";

--- a/ml_metadata/tools/mlmd_bench/benchmark_test.cc
+++ b/ml_metadata/tools/mlmd_bench/benchmark_test.cc
@@ -183,5 +183,76 @@ TEST(BenchmarkTest, CreatFillEventsWorkloadTest) {
   EXPECT_STREQ(benchmark.workload(1)->GetName().c_str(), "FILL_OUTPUT_EVENT");
 }
 
+// Tests the CreateWorkload() for ReadTypes workload, checks that all
+// ReadTypes workload configurations have transformed into executable
+// workloads inside benchmark.
+TEST(BenchmarkTest, CreatReadTypesWorkloadTest) {
+  MLMDBenchConfig mlmd_bench_config =
+      testing::ParseTextProtoOrDie<MLMDBenchConfig>(
+          R"(
+            workload_configs: {
+              read_types_config: { specification: ALL_ARTIFACT_TYPES }
+              num_operations: 120
+            }
+            workload_configs: {
+              read_types_config: { specification: ALL_EXECUTION_TYPES }
+              num_operations: 100
+            }
+            workload_configs: {
+              read_types_config: { specification: ALL_CONTEXT_TYPES }
+              num_operations: 150
+            }
+            workload_configs: {
+              read_types_config: {
+                specification: ARTIFACT_TYPES_BY_IDs
+                maybe_num_ids: { minimum: 1 maximum: 10 }
+              }
+              num_operations: 120
+            }
+            workload_configs: {
+              read_types_config: {
+                specification: EXECUTION_TYPES_BY_IDs
+                maybe_num_ids: { minimum: 1 maximum: 10 }
+              }
+              num_operations: 100
+            }
+            workload_configs: {
+              read_types_config: {
+                specification: CONTEXT_TYPES_BY_IDs
+                maybe_num_ids: { minimum: 1 maximum: 10 }
+              }
+              num_operations: 150
+            }
+            workload_configs: {
+              read_types_config: { specification: ARTIFACT_TYPE_BY_NAME }
+              num_operations: 120
+            }
+            workload_configs: {
+              read_types_config: { specification: EXECUTION_TYPE_BY_NAME }
+              num_operations: 100
+            }
+            workload_configs: {
+              read_types_config: { specification: CONTEXT_TYPE_BY_NAME }
+              num_operations: 150
+            }
+          )");
+  std::vector<std::string> workload_names{
+      "READ_ALL_ARTIFACT_TYPES",     "READ_ALL_EXECUTION_TYPES",
+      "READ_ALL_CONTEXT_TYPES",      "READ_ARTIFACT_TYPES_BY_IDs",
+      "READ_EXECUTION_TYPES_BY_IDs", "READ_CONTEXT_TYPES_BY_IDs",
+      "READ_ARTIFACT_TYPE_BY_NAME",  "READ_EXECUTION_TYPE_BY_NAME",
+      "READ_CONTEXT_TYPE_BY_NAME"};
+
+  Benchmark benchmark(mlmd_bench_config);
+  // Checks that all workload configurations have transformed into executable
+  // workloads inside benchmark.
+  EXPECT_EQ(benchmark.num_workloads(),
+            mlmd_bench_config.workload_configs_size());
+  for (int i = 0; i < mlmd_bench_config.workload_configs_size(); ++i) {
+    EXPECT_STREQ(benchmark.workload(i)->GetName().c_str(),
+                 workload_names[i].c_str());
+  }
+}
+
 }  // namespace
 }  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/proto/mlmd_bench.proto
+++ b/ml_metadata/tools/mlmd_bench/proto/mlmd_bench.proto
@@ -136,6 +136,28 @@ message FillEventsConfig {
   optional UniformDistribution num_events = 5;
 }
 
+// Read types: ArtifactTypes / ExecutionTypes / ContextTypes.
+message ReadTypesConfig {
+  enum Specification {
+    UNKNOWN = 0;
+    ALL_ARTIFACT_TYPES = 1;
+    ALL_EXECUTION_TYPES = 2;
+    ALL_CONTEXT_TYPES = 3;
+    ARTIFACT_TYPES_BY_IDs = 4;
+    EXECUTION_TYPES_BY_IDs = 5;
+    CONTEXT_TYPES_BY_IDs = 6;
+    ARTIFACT_TYPE_BY_NAME = 7;
+    EXECUTION_TYPE_BY_NAME = 8;
+    CONTEXT_TYPE_BY_NAME = 9;
+  }
+  // Indicates which types to be read and how they are read from db.
+  optional Specification specification = 1;
+  // Specifies the number of ids to be filled per request for 
+  // ARTIFACT_TYPES_BY_IDs / EXECUTION_TYPES_BY_IDs / CONTEXT_TYPES_BY_IDs
+  // specification. Modeled by a uniform distribution.
+  optional UniformDistribution maybe_num_ids = 2;
+}
+
 // The mlmd_bench workload config.
 message WorkloadConfig {
   oneof workload_config {
@@ -143,6 +165,7 @@ message WorkloadConfig {
     FillNodesConfig fill_nodes_config = 3;
     FillContextEdgesConfig fill_context_edges_config = 4;
     FillEventsConfig fill_events_config = 5;
+    ReadTypesConfig read_types_config = 6;
   }
   // The number of operations to be run in parallel.
   optional int64 num_operations = 2;

--- a/ml_metadata/tools/mlmd_bench/read_types_workload.cc
+++ b/ml_metadata/tools/mlmd_bench/read_types_workload.cc
@@ -1,0 +1,323 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "ml_metadata/tools/mlmd_bench/read_types_workload.h"
+
+#include <random>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "absl/time/clock.h"
+#include "ml_metadata/metadata_store/metadata_store.h"
+#include "ml_metadata/metadata_store/types.h"
+#include "ml_metadata/proto/metadata_store.pb.h"
+#include "ml_metadata/proto/metadata_store_service.pb.h"
+#include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/util.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace ml_metadata {
+namespace {
+
+constexpr int64 kInt64IdSize = 8;
+constexpr int64 kPropertyTypeSize = 1;
+
+// Gets all types inside db. Returns detailed error if query executions failed.
+// Returns FAILED_PRECONDITION if there is no types inside db to read from.
+tensorflow::Status GetAndValidateExistingTypes(
+    const ReadTypesConfig& read_types_config, MetadataStore& store,
+    std::vector<Type>& existing_types) {
+  TF_RETURN_IF_ERROR(
+      GetExistingTypes(read_types_config, store, existing_types));
+  if (existing_types.empty()) {
+    return tensorflow::errors::FailedPrecondition(
+        "There are no types inside db to read from!");
+  }
+  return tensorflow::Status::OK();
+}
+
+// Calculates the transferred bytes for each types that will be read from later.
+// Returns INVALID_ARGUMENT error if any property of current type is UNKNOWN.
+template <typename T>
+tensorflow::Status GetTransferredBytes(const T& type, int64& curr_bytes) {
+  // Includes the id of current type(int64 takes 8 bytes).
+  curr_bytes += kInt64IdSize;
+  curr_bytes += type.name().size();
+  for (const auto& pair : type.properties()) {
+    // Includes the bytes for properties' name size.
+    curr_bytes += pair.first.size();
+    // Includes the bytes for properties' value enumeration size.
+    if (pair.second == PropertyType::UNKNOWN) {
+      return tensorflow::errors::InvalidArgument("Invalid PropertyType!");
+    }
+    // As we uses a TINYINT to store the enum.
+    curr_bytes += kPropertyTypeSize;
+  }
+  return tensorflow::Status::OK();
+}
+
+// Calculates the transferred bytes for all types inside db that will be read
+// from later.
+template <typename T>
+tensorflow::Status GetTransferredBytesForAllTypes(
+    const std::vector<Type>& existing_types, int64& curr_bytes) {
+  // Loops over all the types and get its transferred bytes one by one.
+  for (const auto& type : existing_types) {
+    TF_RETURN_IF_ERROR(GetTransferredBytes(absl::get<T>(type), curr_bytes));
+  }
+  return tensorflow::Status::OK();
+}
+
+// SetUpImpl() for the specifications to read all types in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadAllTypes(
+    const ReadTypesConfig& read_types_config,
+    const std::vector<Type>& existing_types, ReadTypesWorkItemType& request,
+    int64& curr_bytes) {
+  switch (read_types_config.specification()) {
+    case ReadTypesConfig::ALL_ARTIFACT_TYPES: {
+      request = GetArtifactTypesRequest();
+      return GetTransferredBytesForAllTypes<ArtifactType>(existing_types,
+                                                          curr_bytes);
+    }
+    case ReadTypesConfig::ALL_EXECUTION_TYPES: {
+      request = GetExecutionTypesRequest();
+      return GetTransferredBytesForAllTypes<ExecutionType>(existing_types,
+                                                           curr_bytes);
+    }
+    case ReadTypesConfig::ALL_CONTEXT_TYPES: {
+      request = GetContextTypesRequest();
+      return GetTransferredBytesForAllTypes<ContextType>(existing_types,
+                                                         curr_bytes);
+    }
+    default:
+      return tensorflow::errors::FailedPrecondition(
+          "Wrong ReadTypesConfig specification for read all types in db.");
+  }
+}
+
+// SetUpImpl() for the specifications to read types by a list of ids in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadTypesByIds(
+    const ReadTypesConfig& read_types_config,
+    const std::vector<Type>& existing_types,
+    std::uniform_int_distribution<int64>& type_index_dist,
+    std::minstd_rand0& gen, ReadTypesWorkItemType& request, int64& curr_bytes) {
+  // The number of ids per request will be generated w.r.t. the uniform
+  // distribution `maybe_num_ids`.
+  UniformDistribution num_ids_proto_dist = read_types_config.maybe_num_ids();
+  std::uniform_int_distribution<int64> num_ids_dist{
+      num_ids_proto_dist.minimum(), num_ids_proto_dist.maximum()};
+  const int64 num_ids = num_ids_dist(gen);
+  for (int64 i = 0; i < num_ids; ++i) {
+    // Selects from existing types uniformly.
+    const int64 type_index = type_index_dist(gen);
+    switch (read_types_config.specification()) {
+      case ReadTypesConfig::ARTIFACT_TYPES_BY_IDs: {
+        request = GetArtifactTypesByIDRequest();
+        absl::get<GetArtifactTypesByIDRequest>(request).add_type_ids(
+            absl::get<ArtifactType>(existing_types[type_index]).id());
+        TF_RETURN_IF_ERROR(GetTransferredBytes(
+            absl::get<ArtifactType>(existing_types[type_index]), curr_bytes));
+        break;
+      }
+      case ReadTypesConfig::EXECUTION_TYPES_BY_IDs: {
+        request = GetExecutionTypesByIDRequest();
+        absl::get<GetExecutionTypesByIDRequest>(request).add_type_ids(
+            absl::get<ExecutionType>(existing_types[type_index]).id());
+        TF_RETURN_IF_ERROR(GetTransferredBytes(
+            absl::get<ExecutionType>(existing_types[type_index]), curr_bytes));
+        break;
+      }
+      case ReadTypesConfig::CONTEXT_TYPES_BY_IDs: {
+        request = GetContextTypesByIDRequest();
+        absl::get<GetContextTypesByIDRequest>(request).add_type_ids(
+            absl::get<ContextType>(existing_types[type_index]).id());
+        TF_RETURN_IF_ERROR(GetTransferredBytes(
+            absl::get<ContextType>(existing_types[type_index]), curr_bytes));
+        break;
+      }
+      default:
+        return tensorflow::errors::Unimplemented(
+            "Wrong ReadTypesConfig specification for read types by ids in "
+            "db.");
+    }
+  }
+  return tensorflow::Status::OK();
+}
+
+// SetUpImpl() for the specifications to read type by name in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadTypeByName(
+    const ReadTypesConfig& read_types_config,
+    const std::vector<Type>& existing_types,
+    std::uniform_int_distribution<int64>& type_index_dist,
+    std::minstd_rand0& gen, ReadTypesWorkItemType& request, int64& curr_bytes) {
+  // Selects from existing types uniformly.
+  const int64 type_index = type_index_dist(gen);
+  switch (read_types_config.specification()) {
+    case ReadTypesConfig::ARTIFACT_TYPE_BY_NAME: {
+      request = GetArtifactTypeRequest();
+      absl::get<GetArtifactTypeRequest>(request).set_type_name(
+          absl::get<ArtifactType>(existing_types[type_index]).name());
+      return GetTransferredBytes(
+          absl::get<ArtifactType>(existing_types[type_index]), curr_bytes);
+    }
+    case ReadTypesConfig::EXECUTION_TYPE_BY_NAME: {
+      request = GetExecutionTypeRequest();
+      absl::get<GetExecutionTypeRequest>(request).set_type_name(
+          absl::get<ExecutionType>(existing_types[type_index]).name());
+      return GetTransferredBytes(
+          absl::get<ExecutionType>(existing_types[type_index]), curr_bytes);
+    }
+    case ReadTypesConfig::CONTEXT_TYPE_BY_NAME: {
+      request = GetContextTypeRequest();
+      absl::get<GetContextTypeRequest>(request).set_type_name(
+          absl::get<ContextType>(existing_types[type_index]).name());
+      return GetTransferredBytes(
+          absl::get<ContextType>(existing_types[type_index]), curr_bytes);
+    }
+    default:
+      return tensorflow::errors::Unimplemented(
+          "Wrong ReadTypesConfig specification for read type by name in db.");
+  }
+}
+
+}  // namespace
+
+ReadTypes::ReadTypes(const ReadTypesConfig& read_types_config,
+                     const int64 num_operations)
+    : read_types_config_(read_types_config),
+      num_operations_(num_operations),
+      name_(absl::StrCat("READ_", read_types_config.Specification_Name(
+                                      read_types_config.specification()))) {}
+
+tensorflow::Status ReadTypes::SetUpImpl(MetadataStore* store) {
+  LOG(INFO) << "Setting up ...";
+  int64 curr_bytes = 0;
+
+  // Gets all the specific types in db to choose from when reading types.
+  // If there's no types in the store, returns FAILED_PRECONDITION error.
+  std::vector<Type> existing_types;
+  TF_RETURN_IF_ERROR(
+      GetAndValidateExistingTypes(read_types_config_, *store, existing_types));
+  // Uniform distribution to select existing types uniformly.
+  std::uniform_int_distribution<int64> type_index_dist{
+      0, (int64)(existing_types.size() - 1)};
+  std::minstd_rand0 gen(absl::ToUnixMillis(absl::Now()));
+
+  for (int64 i = 0; i < num_operations_; ++i) {
+    curr_bytes = 0;
+    ReadTypesWorkItemType read_request;
+    switch (read_types_config_.specification()) {
+      case ReadTypesConfig::ALL_ARTIFACT_TYPES:
+      case ReadTypesConfig::ALL_EXECUTION_TYPES:
+      case ReadTypesConfig::ALL_CONTEXT_TYPES:
+        TF_RETURN_IF_ERROR(SetUpImplForReadAllTypes(
+            read_types_config_, existing_types, read_request, curr_bytes));
+        break;
+      case ReadTypesConfig::ARTIFACT_TYPES_BY_IDs:
+      case ReadTypesConfig::EXECUTION_TYPES_BY_IDs:
+      case ReadTypesConfig::CONTEXT_TYPES_BY_IDs:
+        TF_RETURN_IF_ERROR(SetUpImplForReadTypesByIds(
+            read_types_config_, existing_types, type_index_dist, gen,
+            read_request, curr_bytes));
+        break;
+      case ReadTypesConfig::ARTIFACT_TYPE_BY_NAME:
+      case ReadTypesConfig::EXECUTION_TYPE_BY_NAME:
+      case ReadTypesConfig::CONTEXT_TYPE_BY_NAME:
+        TF_RETURN_IF_ERROR(SetUpImplForReadTypeByName(
+            read_types_config_, existing_types, type_index_dist, gen,
+            read_request, curr_bytes));
+        break;
+      default:
+        LOG(FATAL) << "Wrong specification for ReadTypes!";
+    }
+    work_items_.emplace_back(read_request, curr_bytes);
+  }
+  return tensorflow::Status::OK();
+}
+
+// Executions of work items.
+tensorflow::Status ReadTypes::RunOpImpl(const int64 work_items_index,
+                                        MetadataStore* store) {
+  switch (read_types_config_.specification()) {
+    case ReadTypesConfig::ALL_ARTIFACT_TYPES: {
+      auto request = absl::get<GetArtifactTypesRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactTypesResponse response;
+      return store->GetArtifactTypes(request, &response);
+    }
+    case ReadTypesConfig::ALL_EXECUTION_TYPES: {
+      auto request = absl::get<GetExecutionTypesRequest>(
+          work_items_[work_items_index].first);
+      GetExecutionTypesResponse response;
+      return store->GetExecutionTypes(request, &response);
+    }
+    case ReadTypesConfig::ALL_CONTEXT_TYPES: {
+      auto request = absl::get<GetContextTypesRequest>(
+          work_items_[work_items_index].first);
+      GetContextTypesResponse response;
+      return store->GetContextTypes(request, &response);
+    }
+    case ReadTypesConfig::ARTIFACT_TYPES_BY_IDs: {
+      auto request = absl::get<GetArtifactTypesByIDRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactTypesByIDResponse response;
+      return store->GetArtifactTypesByID(request, &response);
+    }
+    case ReadTypesConfig::EXECUTION_TYPES_BY_IDs: {
+      auto request = absl::get<GetExecutionTypesByIDRequest>(
+          work_items_[work_items_index].first);
+      GetExecutionTypesByIDResponse response;
+      return store->GetExecutionTypesByID(request, &response);
+    }
+    case ReadTypesConfig::CONTEXT_TYPES_BY_IDs: {
+      auto request = absl::get<GetContextTypesByIDRequest>(
+          work_items_[work_items_index].first);
+      GetContextTypesByIDResponse response;
+      return store->GetContextTypesByID(request, &response);
+    }
+    case ReadTypesConfig::ARTIFACT_TYPE_BY_NAME: {
+      auto request = absl::get<GetArtifactTypeRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactTypeResponse response;
+      return store->GetArtifactType(request, &response);
+    }
+    case ReadTypesConfig::EXECUTION_TYPE_BY_NAME: {
+      auto request = absl::get<GetExecutionTypeRequest>(
+          work_items_[work_items_index].first);
+      GetExecutionTypeResponse response;
+      return store->GetExecutionType(request, &response);
+    }
+    case ReadTypesConfig::CONTEXT_TYPE_BY_NAME: {
+      auto request =
+          absl::get<GetContextTypeRequest>(work_items_[work_items_index].first);
+      GetContextTypeResponse response;
+      return store->GetContextType(request, &response);
+    }
+    default:
+      return tensorflow::errors::InvalidArgument("Wrong specification!");
+  }
+}
+
+tensorflow::Status ReadTypes::TearDownImpl() {
+  work_items_.clear();
+  return tensorflow::Status::OK();
+}
+
+std::string ReadTypes::GetName() { return name_; }
+
+}  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/read_types_workload.h
+++ b/ml_metadata/tools/mlmd_bench/read_types_workload.h
@@ -1,0 +1,83 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef ML_METADATA_TOOLS_MLMD_BENCH_READ_TYPES_WORKLOAD_H
+#define ML_METADATA_TOOLS_MLMD_BENCH_READ_TYPES_WORKLOAD_H
+
+#include "absl/types/variant.h"
+#include "ml_metadata/metadata_store/metadata_store.h"
+#include "ml_metadata/metadata_store/types.h"
+#include "ml_metadata/proto/metadata_store_service.pb.h"
+#include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/workload.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace ml_metadata {
+
+// Defines a ReadTypesWorkItemType that can be GetArtifactTypesRequest /
+// GetExecutionTypesRequest / GetContextTypesRequest /
+// GetArtifactTypesByIDRequest / GetExecutionTypesByIDRequest /
+// GetContextTypesByIDRequest / GetArtifactTypeRequest / GetExecutionTypeRequest
+// / GetContextTypeRequest.
+using ReadTypesWorkItemType =
+    ::absl::variant<GetArtifactTypesRequest, GetExecutionTypesRequest,
+                    GetContextTypesRequest, GetArtifactTypesByIDRequest,
+                    GetExecutionTypesByIDRequest, GetContextTypesByIDRequest,
+                    GetArtifactTypeRequest, GetExecutionTypeRequest,
+                    GetContextTypeRequest>;
+
+// A specific workload for getting types: ArtifactTypes / ExecutionTypes /
+// ContextTypes.
+class ReadTypes : public Workload<ReadTypesWorkItemType> {
+ public:
+  ReadTypes(const ReadTypesConfig& read_types_config, int64 num_operations);
+  ~ReadTypes() override = default;
+
+ protected:
+  // Specific implementation of SetUpImpl() for ReadTypes workload according to
+  // its semantic. A list of work items(ReadTypesWorkItemType) will be
+  // generated. When querying types by parameters, select from existing types
+  // uniformly to finalize the query string. If the specification of current
+  // workload is ARTIFACT_TYPES_BY_IDs / EXECUTION_TYPES_BY_IDs /
+  // CONTEXT_TYPES_BY_IDs, the number of ids per request will be generated
+  // w.r.t. the uniform distribution `maybe_num_ids`. Returns detailed error if
+  // query executions failed.
+  tensorflow::Status SetUpImpl(MetadataStore* store) final;
+
+  // Specific implementation of RunOpImpl() for ReadTypes workload according to
+  // its semantic. Runs the work items(ReadTypesWorkItemType) on the store.
+  // Returns detailed error if query executions failed.
+  tensorflow::Status RunOpImpl(int64 work_items_index,
+                               MetadataStore* store) final;
+
+  // Specific implementation of TearDownImpl() for ReadTypes workload according
+  // to its semantic. Cleans the work items.
+  tensorflow::Status TearDownImpl() final;
+
+  // Gets the current workload's name, which is used in stats report for this
+  // workload.
+  std::string GetName() final;
+
+ private:
+  // Workload configurations specified by the users.
+  const ReadTypesConfig read_types_config_;
+  // Number of operations for the current workload.
+  const int64 num_operations_;
+  // String for indicating the name of current workload instance.
+  std::string name_;
+};
+
+}  // namespace ml_metadata
+
+#endif  // ML_METADATA_TOOLS_MLMD_BENCH_READ_TYPES_WORKLOAD_H

--- a/ml_metadata/tools/mlmd_bench/read_types_workload_test.cc
+++ b/ml_metadata/tools/mlmd_bench/read_types_workload_test.cc
@@ -1,0 +1,119 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "ml_metadata/tools/mlmd_bench/read_types_workload.h"
+
+#include <gtest/gtest.h>
+#include "absl/memory/memory.h"
+#include "ml_metadata/metadata_store/metadata_store.h"
+#include "ml_metadata/metadata_store/metadata_store_factory.h"
+#include "ml_metadata/metadata_store/test_util.h"
+#include "ml_metadata/proto/metadata_store.pb.h"
+#include "ml_metadata/proto/metadata_store_service.pb.h"
+#include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/util.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+
+namespace ml_metadata {
+namespace {
+
+constexpr int kNumberOfOperations = 100;
+constexpr int kNumberOfExistedTypesInDb = 300;
+
+constexpr char kConfig[] =
+    "read_types_config: { maybe_num_ids { minimum: 1 maximum: 10 } }";
+
+// Enumerates the workload configurations as the test parameters that ensure
+// test coverage.
+std::vector<WorkloadConfig> EnumerateConfigs() {
+  std::vector<WorkloadConfig> configs;
+  std::vector<ReadTypesConfig::Specification> specifications = {
+      ReadTypesConfig::ALL_ARTIFACT_TYPES,
+      ReadTypesConfig::ALL_EXECUTION_TYPES,
+      ReadTypesConfig::ALL_CONTEXT_TYPES,
+      ReadTypesConfig::ARTIFACT_TYPES_BY_IDs,
+      ReadTypesConfig::EXECUTION_TYPES_BY_IDs,
+      ReadTypesConfig::CONTEXT_TYPES_BY_IDs,
+      ReadTypesConfig::ARTIFACT_TYPE_BY_NAME,
+      ReadTypesConfig::EXECUTION_TYPE_BY_NAME,
+      ReadTypesConfig::CONTEXT_TYPE_BY_NAME};
+
+  for (const ReadTypesConfig::Specification& specification : specifications) {
+    WorkloadConfig config =
+        testing::ParseTextProtoOrDie<WorkloadConfig>(kConfig);
+    config.set_num_operations(kNumberOfOperations);
+    config.mutable_read_types_config()->set_specification(specification);
+    configs.push_back(config);
+  }
+
+  return configs;
+}
+
+// Test fixture that uses the same data configuration for multiple following
+// parameterized ReadTypes tests.
+// The parameter here is the specific Workload configuration that contains
+// the ReadTypes configuration and the number of operations.
+class ReadTypesParameterizedTestFixture
+    : public ::testing::TestWithParam<WorkloadConfig> {
+ protected:
+  void SetUp() override {
+    ConnectionConfig mlmd_config;
+    // Uses a fake in-memory SQLite database for testing.
+    mlmd_config.mutable_fake_database();
+    TF_ASSERT_OK(CreateMetadataStore(mlmd_config, &store_));
+    read_types_ = absl::make_unique<ReadTypes>(
+        ReadTypes(GetParam().read_types_config(), GetParam().num_operations()));
+    TF_ASSERT_OK(InsertTypesInDb(
+        /*num_artifact_types=*/kNumberOfExistedTypesInDb,
+        /*num_execution_types=*/kNumberOfExistedTypesInDb,
+        /*num_context_types=*/kNumberOfExistedTypesInDb, *store_));
+  }
+
+  std::unique_ptr<ReadTypes> read_types_;
+  std::unique_ptr<MetadataStore> store_;
+};
+
+// Tests the SetUpImpl() for ReadTypes. Checks the SetUpImpl() indeed prepares
+// a list of work items whose length is the same as the specified number of
+// operations.
+TEST_P(ReadTypesParameterizedTestFixture, SetUpImplTest) {
+  TF_ASSERT_OK(read_types_->SetUp(store_.get()));
+  EXPECT_EQ(GetParam().num_operations(), read_types_->num_operations());
+}
+
+// Tests the RunOpImpl() for ReadTypes. Checks indeed all the work items have
+// been executed and some bytes are transferred during the reading process.
+TEST_P(ReadTypesParameterizedTestFixture, RunOpImplTest) {
+  TF_ASSERT_OK(read_types_->SetUp(store_.get()));
+
+  int64 total_done = 0;
+  ThreadStats stats;
+  stats.Start();
+  for (int64 i = 0; i < read_types_->num_operations(); ++i) {
+    OpStats op_stats;
+    TF_ASSERT_OK(read_types_->RunOp(i, store_.get(), op_stats));
+    stats.Update(op_stats, total_done);
+  }
+  stats.Stop();
+  EXPECT_EQ(GetParam().num_operations(), stats.done());
+  // Checks that the transferred bytes is greater that 0(the reading process
+  // indeed occurred).
+  EXPECT_LT(0, stats.bytes());
+}
+
+INSTANTIATE_TEST_CASE_P(ReadTypesTest, ReadTypesParameterizedTestFixture,
+                        ::testing::ValuesIn(EnumerateConfigs()));
+
+}  // namespace
+}  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/util.cc
+++ b/ml_metadata/tools/mlmd_bench/util.cc
@@ -127,47 +127,61 @@ tensorflow::Status GetExistingNodesImpl(const FetchNode& fetch_node,
 tensorflow::Status GetExistingTypes(const FillTypesConfig& fill_types_config,
                                     MetadataStore& store,
                                     std::vector<Type>& existing_types) {
-  FetchType fetch_type;
   switch (fill_types_config.specification()) {
     case FillTypesConfig::ARTIFACT_TYPE: {
-      fetch_type = FetchArtifactType;
-      break;
+      return GetExistingTypesImpl(FetchArtifactType, store, existing_types);
     }
     case FillTypesConfig::EXECUTION_TYPE: {
-      fetch_type = FetchExecutionType;
-      break;
+      return GetExistingTypesImpl(FetchExecutionType, store, existing_types);
     }
     case FillTypesConfig::CONTEXT_TYPE: {
-      fetch_type = FetchContextType;
-      break;
+      return GetExistingTypesImpl(FetchContextType, store, existing_types);
     }
     default:
-      LOG(FATAL) << "Wrong specification for getting types in db!";
+      return tensorflow::errors::Unimplemented(
+          "Unknown FillTypesConfig specification.");
   }
-  return GetExistingTypesImpl(fetch_type, store, existing_types);
 }
 
 tensorflow::Status GetExistingTypes(const FillNodesConfig& fill_nodes_config,
                                     MetadataStore& store,
                                     std::vector<Type>& existing_types) {
-  FetchType fetch_type;
   switch (fill_nodes_config.specification()) {
     case FillNodesConfig::ARTIFACT: {
-      fetch_type = FetchArtifactType;
-      break;
+      return GetExistingTypesImpl(FetchArtifactType, store, existing_types);
     }
     case FillNodesConfig::EXECUTION: {
-      fetch_type = FetchExecutionType;
-      break;
+      return GetExistingTypesImpl(FetchExecutionType, store, existing_types);
     }
     case FillNodesConfig::CONTEXT: {
-      fetch_type = FetchContextType;
-      break;
+      return GetExistingTypesImpl(FetchContextType, store, existing_types);
     }
     default:
-      LOG(FATAL) << "Wrong specification for getting types in db!";
+      return tensorflow::errors::Unimplemented(
+          "Unknown FillNodesConfig specification.");
   }
-  return GetExistingTypesImpl(fetch_type, store, existing_types);
+}
+
+tensorflow::Status GetExistingTypes(const ReadTypesConfig& read_types_config,
+                                    MetadataStore& store,
+                                    std::vector<Type>& existing_types) {
+  switch (read_types_config.specification()) {
+    case ReadTypesConfig::ALL_ARTIFACT_TYPES:
+    case ReadTypesConfig::ARTIFACT_TYPES_BY_IDs:
+    case ReadTypesConfig::ARTIFACT_TYPE_BY_NAME:
+      return GetExistingTypesImpl(FetchArtifactType, store, existing_types);
+    case ReadTypesConfig::ALL_EXECUTION_TYPES:
+    case ReadTypesConfig::EXECUTION_TYPES_BY_IDs:
+    case ReadTypesConfig::EXECUTION_TYPE_BY_NAME:
+      return GetExistingTypesImpl(FetchExecutionType, store, existing_types);
+    case ReadTypesConfig::ALL_CONTEXT_TYPES:
+    case ReadTypesConfig::CONTEXT_TYPES_BY_IDs:
+    case ReadTypesConfig::CONTEXT_TYPE_BY_NAME:
+      return GetExistingTypesImpl(FetchContextType, store, existing_types);
+    default:
+      return tensorflow::errors::Unimplemented(
+          "Unknown ReadTypesConfig specification.");
+  }
 }
 
 tensorflow::Status GetExistingNodes(const FillNodesConfig& fill_nodes_config,

--- a/ml_metadata/tools/mlmd_bench/util.h
+++ b/ml_metadata/tools/mlmd_bench/util.h
@@ -45,6 +45,12 @@ tensorflow::Status GetExistingTypes(const FillNodesConfig& fill_nodes_config,
                                     MetadataStore& store,
                                     std::vector<Type>& existing_types);
 
+// Gets all the existing types inside db and store them into `existing_types`
+// given `read_types_config`. Returns detailed error if query executions failed.
+tensorflow::Status GetExistingTypes(const ReadTypesConfig& read_types_config,
+                                    MetadataStore& store,
+                                    std::vector<Type>& existing_types);
+
 // Gets all the existing nodes inside db and store them into `existing_nodes`
 // given `fill_nodes_config`.
 // Returns detailed error if query executions failed.


### PR DESCRIPTION
Supports benchmarking the performance of GetArtifactTypes(), GetExecutionTypes(), GetContextTypes(), GetArtifactTypesByID(), GetExecutionTypesByID(), GetContextTypesByID(), GetArtifactType(), GetExecutionType() and GetContextType() APIs.

