### PR TITLE
Adds ReadNodesByProperties workload for mlmd_bench.

### DIFF
--- a/ml_metadata/tools/mlmd_bench/BUILD
+++ b/ml_metadata/tools/mlmd_bench/BUILD
@@ -211,6 +211,44 @@ ml_metadata_cc_test(
 )
 
 cc_library(
+    name = "read_nodes_by_properties_workload",
+    srcs = ["read_nodes_by_properties_workload.cc"],
+    hdrs = ["read_nodes_by_properties_workload.h"],
+    deps = [
+        ":workload",
+        ":util",
+        "@com_google_absl//absl/time",
+        "//ml_metadata/metadata_store:metadata_store",
+        "//ml_metadata/metadata_store:types",
+        "//ml_metadata/proto:metadata_store_proto",
+        "//ml_metadata/proto:metadata_store_service_proto",
+        "//ml_metadata/tools/mlmd_bench/proto:mlmd_bench_proto",
+        "@org_tensorflow//tensorflow/core:lib",
+    ],
+)
+
+ml_metadata_cc_test(
+    name = "read_nodes_by_properties_workload_test",
+    size = "small",
+    srcs = ["read_nodes_by_properties_workload_test.cc"],
+    deps = [
+        ":read_nodes_by_properties_workload",
+        ":util",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/memory",
+        "//ml_metadata/metadata_store",
+        "//ml_metadata/metadata_store:metadata_store_factory",
+        "//ml_metadata/metadata_store:test_util",
+        "//ml_metadata/metadata_store:types",
+        "//ml_metadata/proto:metadata_store_proto",
+        "//ml_metadata/proto:metadata_store_service_proto",
+        "//ml_metadata/tools/mlmd_bench/proto:mlmd_bench_proto",
+        "@org_tensorflow//tensorflow/core:test",
+    ],
+)
+
+
+cc_library(
     name = "stats",
     srcs = ["stats.cc"],
     hdrs = ["stats.h"],
@@ -243,6 +281,7 @@ cc_library(
         ":fill_events_workload",
         ":fill_nodes_workload",
         ":fill_types_workload",
+        ":read_nodes_by_properties_workload",
         ":read_types_workload",
         ":workload",
         "@com_google_absl//absl/memory",

--- a/ml_metadata/tools/mlmd_bench/benchmark.cc
+++ b/ml_metadata/tools/mlmd_bench/benchmark.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "ml_metadata/tools/mlmd_bench/fill_nodes_workload.h"
 #include "ml_metadata/tools/mlmd_bench/fill_types_workload.h"
 #include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.h"
 #include "ml_metadata/tools/mlmd_bench/read_types_workload.h"
 #include "ml_metadata/tools/mlmd_bench/workload.h"
 
@@ -57,6 +58,11 @@ std::unique_ptr<WorkloadBase> CreateWorkload(
       return absl::make_unique<ReadTypes>(
           ReadTypes(workload_config.read_types_config(),
                     workload_config.num_operations()));
+    }
+    case WorkloadConfig::kReadNodesByPropertiesConfig: {
+      return absl::make_unique<ReadNodesByProperties>(ReadNodesByProperties(
+          workload_config.read_nodes_by_properties_config(),
+          workload_config.num_operations()));
     }
     default:
       LOG(FATAL) << "Cannot find corresponding workload!";

--- a/ml_metadata/tools/mlmd_bench/benchmark_test.cc
+++ b/ml_metadata/tools/mlmd_bench/benchmark_test.cc
@@ -254,5 +254,93 @@ TEST(BenchmarkTest, CreatReadTypesWorkloadTest) {
   }
 }
 
+// Tests the CreateWorkload() for ReadNodesByProperties workload, checks that
+// all ReadNodesByProperties workload configurations have transformed into
+// executable workloads inside benchmark.
+TEST(BenchmarkTest, CreatReadNodesByPropertiesWorkloadTest) {
+  MLMDBenchConfig mlmd_bench_config = testing::ParseTextProtoOrDie<
+      MLMDBenchConfig>(
+      R"(
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: ARTIFACTS_BY_ID
+            num_of_parameters: { minimum: 1 maximum: 10 }
+          }
+          num_operations: 120
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: EXECUTIONS_BY_ID
+            num_of_parameters: { minimum: 1 maximum: 10 }
+          }
+          num_operations: 100
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: CONTEXTS_BY_ID
+            num_of_parameters: { minimum: 1 maximum: 10 }
+          }
+          num_operations: 150
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: { specification: ARTIFACTS_BY_TYPE }
+          num_operations: 120
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: { specification: EXECUTIONS_BY_TYPE }
+          num_operations: 100
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: { specification: CONTEXTS_BY_TYPE }
+          num_operations: 150
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: ARTIFACT_BY_TYPE_AND_NAME
+          }
+          num_operations: 120
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: EXECUTION_BY_TYPE_AND_NAME
+          }
+          num_operations: 100
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: CONTEXT_BY_TYPE_AND_NAME
+          }
+          num_operations: 150
+        }
+        workload_configs: {
+          read_nodes_by_properties_config: {
+            specification: ARTIFACTS_BY_URI
+            num_of_parameters: { minimum: 1 maximum: 10 }
+          }
+          num_operations: 150
+        }
+      )");
+  std::vector<std::string> workload_names{"READ_ARTIFACTS_BY_ID",
+                                          "READ_EXECUTIONS_BY_ID",
+                                          "READ_CONTEXTS_BY_ID",
+                                          "READ_ARTIFACTS_BY_TYPE",
+                                          "READ_EXECUTIONS_BY_TYPE",
+                                          "READ_CONTEXTS_BY_TYPE",
+                                          "READ_ARTIFACT_BY_TYPE_AND_NAME",
+                                          "READ_EXECUTION_BY_TYPE_AND_NAME",
+                                          "READ_CONTEXT_BY_TYPE_AND_NAME",
+                                          "READ_ARTIFACTS_BY_URI"};
+
+  Benchmark benchmark(mlmd_bench_config);
+  // Checks that all workload configurations have transformed into executable
+  // workloads inside benchmark.
+  EXPECT_EQ(benchmark.num_workloads(),
+            mlmd_bench_config.workload_configs_size());
+  for (int i = 0; i < mlmd_bench_config.workload_configs_size(); ++i) {
+    EXPECT_STREQ(benchmark.workload(i)->GetName().c_str(),
+                 workload_names[i].c_str());
+  }
+}
+
 }  // namespace
 }  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/proto/mlmd_bench.proto
+++ b/ml_metadata/tools/mlmd_bench/proto/mlmd_bench.proto
@@ -136,7 +136,7 @@ message FillEventsConfig {
   optional UniformDistribution num_events = 5;
 }
 
-// Read types: ArtifactTypes / ExecutionTypes / ContextTypes.
+// Reads types: ArtifactTypes / ExecutionTypes / ContextTypes.
 message ReadTypesConfig {
   enum Specification {
     UNKNOWN = 0;
@@ -158,6 +158,32 @@ message ReadTypesConfig {
   optional UniformDistribution maybe_num_ids = 2;
 }
 
+// Reads nodes: Artifacts / Executions / Contexts by their properties.
+message ReadNodesByPropertiesConfig {
+  enum Specification {
+    UNKNOWN = 0;
+    ARTIFACTS_BY_ID = 1;
+    EXECUTIONS_BY_ID = 2;
+    CONTEXTS_BY_ID = 3;
+    ARTIFACTS_BY_TYPE = 4;
+    EXECUTIONS_BY_TYPE = 5;
+    CONTEXTS_BY_TYPE = 6;
+    ARTIFACT_BY_TYPE_AND_NAME = 7;
+    EXECUTION_BY_TYPE_AND_NAME = 8;
+    CONTEXT_BY_TYPE_AND_NAME = 9;
+    ARTIFACTS_BY_URI = 10;
+  }
+  // Indicates which property (id, type, name, etc.)  
+  // should be used to get nodes (artifacts, executions, contexts).
+  optional Specification specification = 1;
+  // When the specification is ARTIFACTS_BY_ID / EXECUTIONS_BY_ID / 
+  // CONTEXTS_BY_ID, `num_of_parameters` will be the number of ids
+  // per request. When the specification is ARTIFACTS_BY_URI, 
+  // `num_of_parameters` will be the number of uris per request.
+  // Modeled by a uniform distribution.
+  optional UniformDistribution num_of_parameters = 2;
+}
+
 // The mlmd_bench workload config.
 message WorkloadConfig {
   oneof workload_config {
@@ -166,6 +192,7 @@ message WorkloadConfig {
     FillContextEdgesConfig fill_context_edges_config = 4;
     FillEventsConfig fill_events_config = 5;
     ReadTypesConfig read_types_config = 6;
+    ReadNodesByPropertiesConfig read_nodes_by_properties_config = 7;
   }
   // The number of operations to be run in parallel.
   optional int64 num_operations = 2;

--- a/ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.cc
+++ b/ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.cc
@@ -1,0 +1,435 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.h"
+
+#include <random>
+#include <vector>
+
+#include "absl/time/clock.h"
+#include "ml_metadata/metadata_store/metadata_store.h"
+#include "ml_metadata/metadata_store/types.h"
+#include "ml_metadata/proto/metadata_store.pb.h"
+#include "ml_metadata/proto/metadata_store_service.pb.h"
+#include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/util.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace ml_metadata {
+namespace {
+
+constexpr int64 kInt64IdSize = 8;
+constexpr int64 kInt64TypeIdSize = 8;
+constexpr int64 kInt64CreateTimeSize = 8;
+constexpr int64 kInt64LastUpdateTimeSize = 8;
+constexpr int64 kEnumStateSize = 1;
+
+// Gets all nodes inside db. Returns detailed error if query executions failed.
+// Returns FAILED_PRECONDITION if there is no nodes inside db to read from.
+tensorflow::Status GetAndValidateExistingNodes(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    MetadataStore& store, std::vector<Node>& existing_nodes) {
+  TF_RETURN_IF_ERROR(
+      GetExistingNodes(read_nodes_by_properties_config, store, existing_nodes));
+  if (existing_nodes.empty()) {
+    return tensorflow::errors::FailedPrecondition(
+        "There are no nodes inside db to read from!");
+  }
+  return tensorflow::Status::OK();
+}
+
+// Gets the transferred bytes for certain `properties` and returns their bytes.
+int64 GetTransferredBytesForNodeProperties(
+    const google::protobuf::Map<std::string, Value>& properties) {
+  int64 bytes = 0;
+  for (auto& pair : properties) {
+    // Includes the bytes for properties' name size.
+    bytes += pair.first.size();
+    // Includes the bytes for properties' value size.
+    bytes += pair.second.string_value().size();
+  }
+  return bytes;
+}
+
+// Gets the transferred bytes for certain Artifact.
+int64 GetTransferredBytes(const Artifact& node) {
+  int64 bytes = kInt64IdSize + kInt64TypeIdSize + kInt64CreateTimeSize +
+                kInt64LastUpdateTimeSize;
+  bytes += node.name().size();
+  bytes += node.type().size();
+  bytes += node.uri().size();
+  bytes += kEnumStateSize;
+  bytes += GetTransferredBytesForNodeProperties(node.properties());
+  bytes += GetTransferredBytesForNodeProperties(node.custom_properties());
+  return bytes;
+}
+
+// Gets the transferred bytes for certain Execution.
+int64 GetTransferredBytes(const Execution& node) {
+  int64 bytes = kInt64IdSize + kInt64TypeIdSize + kInt64CreateTimeSize +
+                kInt64LastUpdateTimeSize;
+  bytes += node.name().size();
+  bytes += node.type().size();
+  bytes += kEnumStateSize;
+  bytes += GetTransferredBytesForNodeProperties(node.properties());
+  bytes += GetTransferredBytesForNodeProperties(node.custom_properties());
+  return bytes;
+}
+
+// Gets the transferred bytes for certain Context.
+int64 GetTransferredBytes(const Context& node) {
+  int64 bytes = kInt64IdSize + kInt64TypeIdSize + kInt64CreateTimeSize +
+                kInt64LastUpdateTimeSize;
+  bytes += node.name().size();
+  bytes += node.type().size();
+  bytes += GetTransferredBytesForNodeProperties(node.properties());
+  bytes += GetTransferredBytesForNodeProperties(node.custom_properties());
+  return bytes;
+}
+
+// Gets the transferred bytes for all nodes under a certain type.
+template <typename NT>
+int64 GetTransferredBytesForAllNodesUnderAType(
+    const std::string type_name, const std::vector<Node>& existing_nodes) {
+  int64 bytes = 0;
+  for (auto& node : existing_nodes) {
+    if (absl::get<NT>(node).type() == type_name) {
+      bytes += GetTransferredBytes(absl::get<NT>(node));
+    }
+  }
+  return bytes;
+}
+
+// SetUpImpl() for the specifications to read nodes by a list of ids in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadNodesByIds(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    const std::vector<Node>& existing_nodes,
+    std::uniform_int_distribution<int64>& node_index_dist,
+    std::minstd_rand0& gen, ReadNodesByPropertiesWorkItemType& request,
+    int64& curr_bytes) {
+  UniformDistribution num_ids_proto_dist =
+      read_nodes_by_properties_config.num_of_parameters();
+  std::uniform_int_distribution<int64> num_ids_dist{
+      num_ids_proto_dist.minimum(), num_ids_proto_dist.maximum()};
+  // Specifies the number of ids to put inside each request.
+  const int64 num_ids = num_ids_dist(gen);
+  for (int64 i = 0; i < num_ids; ++i) {
+    // Selects from existing nodes uniformly to get a node id.
+    const int64 node_index = node_index_dist(gen);
+    switch (read_nodes_by_properties_config.specification()) {
+      case ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID: {
+        request = GetArtifactsByIDRequest();
+        absl::get<GetArtifactsByIDRequest>(request).add_artifact_ids(
+            absl::get<Artifact>(existing_nodes[node_index]).id());
+        curr_bytes += GetTransferredBytes(
+            absl::get<Artifact>(existing_nodes[node_index]));
+        break;
+      }
+      case ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID: {
+        request = GetExecutionsByIDRequest();
+        absl::get<GetExecutionsByIDRequest>(request).add_execution_ids(
+            absl::get<Execution>(existing_nodes[node_index]).id());
+        curr_bytes += GetTransferredBytes(
+            absl::get<Execution>(existing_nodes[node_index]));
+        break;
+      }
+      case ReadNodesByPropertiesConfig::CONTEXTS_BY_ID: {
+        request = GetContextsByIDRequest();
+        absl::get<GetContextsByIDRequest>(request).add_context_ids(
+            absl::get<Context>(existing_nodes[node_index]).id());
+        curr_bytes +=
+            GetTransferredBytes(absl::get<Context>(existing_nodes[node_index]));
+        break;
+      }
+      default:
+        LOG(FATAL) << "Wrong ReadNodesByProperties specification for read "
+                      "nodes by ids in db.";
+    }
+  }
+  return tensorflow::Status::OK();
+}
+
+// SetUpImpl() for the specifications to read artifacts by a list of uris in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadArtifactsByURIs(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    const std::vector<Node>& existing_nodes,
+    std::uniform_int_distribution<int64>& node_index_dist,
+    std::minstd_rand0& gen, ReadNodesByPropertiesWorkItemType& request,
+    int64& curr_bytes) {
+  if (read_nodes_by_properties_config.specification() !=
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI) {
+    LOG(FATAL) << "Wrong ReadNodesByProperties specification for read "
+                  "artifacts by uris in db.";
+  }
+  UniformDistribution num_uris_proto_dist =
+      read_nodes_by_properties_config.num_of_parameters();
+  std::uniform_int_distribution<int64> num_uris_dist{
+      num_uris_proto_dist.minimum(), num_uris_proto_dist.maximum()};
+  // Specifies the number of uris to put inside each request.
+  const int64 num_uris = num_uris_dist(gen);
+  for (int64 i = 0; i < num_uris; ++i) {
+    // Selects from existing nodes uniformly to get a node uri.
+    const int64 node_index = node_index_dist(gen);
+    request = GetArtifactsByURIRequest();
+    absl::get<GetArtifactsByURIRequest>(request).add_uris(
+        absl::get<Artifact>(existing_nodes[node_index]).uri());
+    curr_bytes +=
+        GetTransferredBytes(absl::get<Artifact>(existing_nodes[node_index]));
+  }
+  return tensorflow::Status::OK();
+}
+
+// SetUpImpl() for the specifications to read artifacts by type in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadNodesByType(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    const std::vector<Node>& existing_nodes,
+    std::uniform_int_distribution<int64>& node_index_dist,
+    std::minstd_rand0& gen, ReadNodesByPropertiesWorkItemType& request,
+    int64& curr_bytes) {
+  if (read_nodes_by_properties_config.has_num_of_parameters()) {
+    LOG(FATAL) << "ReadNodesByType specification should not have a "
+                  "`num_of_parameters` field!";
+  }
+  // Selects from existing nodes uniformly to get a type.
+  const int64 node_index = node_index_dist(gen);
+  switch (read_nodes_by_properties_config.specification()) {
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_TYPE: {
+      request = GetArtifactsByTypeRequest();
+      absl::get<GetArtifactsByTypeRequest>(request).set_type_name(
+          absl::get<Artifact>(existing_nodes[node_index]).type());
+      curr_bytes += GetTransferredBytesForAllNodesUnderAType<Artifact>(
+          absl::get<Artifact>(existing_nodes[node_index]).type(),
+          existing_nodes);
+      break;
+    }
+    case ReadNodesByPropertiesConfig::EXECUTIONS_BY_TYPE: {
+      request = GetExecutionsByTypeRequest();
+      absl::get<GetExecutionsByTypeRequest>(request).set_type_name(
+          absl::get<Execution>(existing_nodes[node_index]).type());
+      curr_bytes += GetTransferredBytesForAllNodesUnderAType<Execution>(
+          absl::get<Execution>(existing_nodes[node_index]).type(),
+          existing_nodes);
+      break;
+    }
+    case ReadNodesByPropertiesConfig::CONTEXTS_BY_TYPE: {
+      request = GetContextsByTypeRequest();
+      absl::get<GetContextsByTypeRequest>(request).set_type_name(
+          absl::get<Context>(existing_nodes[node_index]).type());
+      curr_bytes += GetTransferredBytesForAllNodesUnderAType<Context>(
+          absl::get<Context>(existing_nodes[node_index]).type(),
+          existing_nodes);
+      break;
+    }
+    default:
+      LOG(FATAL) << "Wrong ReadNodesByProperties specification for read nodes "
+                    "by type in db.";
+  }
+  return tensorflow::Status::OK();
+}
+
+// SetUpImpl() for the specifications to read artifacts by name and type in db.
+// Returns detailed error if query executions failed.
+tensorflow::Status SetUpImplForReadNodeByTypeAndName(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    const std::vector<Node>& existing_nodes,
+    std::uniform_int_distribution<int64>& node_index_dist,
+    std::minstd_rand0& gen, ReadNodesByPropertiesWorkItemType& request,
+    int64& curr_bytes) {
+  if (read_nodes_by_properties_config.has_num_of_parameters()) {
+    LOG(FATAL) << "ReadNodesByTypeAndName specification should not have a "
+                  "`num_of_parameters` field!";
+  }
+  // Selects from existing nodes uniformly to get a name and a type.
+  const int64 node_index = node_index_dist(gen);
+  switch (read_nodes_by_properties_config.specification()) {
+    case ReadNodesByPropertiesConfig::ARTIFACT_BY_TYPE_AND_NAME: {
+      request = GetArtifactByTypeAndNameRequest();
+      Artifact picked_node = absl::get<Artifact>(existing_nodes[node_index]);
+      absl::get<GetArtifactByTypeAndNameRequest>(request).set_type_name(
+          picked_node.type());
+      absl::get<GetArtifactByTypeAndNameRequest>(request).set_artifact_name(
+          picked_node.name());
+      curr_bytes += GetTransferredBytes(picked_node);
+      break;
+    }
+    case ReadNodesByPropertiesConfig::EXECUTION_BY_TYPE_AND_NAME: {
+      request = GetExecutionByTypeAndNameRequest();
+      Execution picked_node = absl::get<Execution>(existing_nodes[node_index]);
+      absl::get<GetExecutionByTypeAndNameRequest>(request).set_type_name(
+          picked_node.type());
+      absl::get<GetExecutionByTypeAndNameRequest>(request).set_execution_name(
+          picked_node.name());
+      curr_bytes += GetTransferredBytes(picked_node);
+      break;
+    }
+    case ReadNodesByPropertiesConfig::CONTEXT_BY_TYPE_AND_NAME: {
+      request = GetContextByTypeAndNameRequest();
+      Context picked_node = absl::get<Context>(existing_nodes[node_index]);
+      absl::get<GetContextByTypeAndNameRequest>(request).set_type_name(
+          picked_node.type());
+      absl::get<GetContextByTypeAndNameRequest>(request).set_context_name(
+          picked_node.name());
+      curr_bytes += GetTransferredBytes(picked_node);
+      break;
+    }
+    default:
+      LOG(FATAL) << "Wrong ReadNodesByProperties specification for read node "
+                    "by type and name in db.";
+  }
+  return tensorflow::Status::OK();
+}
+
+}  // namespace
+
+ReadNodesByProperties::ReadNodesByProperties(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    const int64 num_operations)
+    : read_nodes_by_properties_config_(read_nodes_by_properties_config),
+      num_operations_(num_operations),
+      name_(absl::StrCat(
+          "READ_", read_nodes_by_properties_config_.Specification_Name(
+                       read_nodes_by_properties_config_.specification()))) {}
+
+tensorflow::Status ReadNodesByProperties::SetUpImpl(MetadataStore* store) {
+  LOG(INFO) << "Setting up ...";
+
+  // Gets all the specific nodes in db to choose from when reading nodes.
+  // If there's no nodes in the store, returns FAILED_PRECONDITION error.
+  std::vector<Node> existing_nodes;
+  TF_RETURN_IF_ERROR(GetAndValidateExistingNodes(
+      read_nodes_by_properties_config_, *store, existing_nodes));
+  // Uniform distribution to select existing nodes uniformly.
+  std::uniform_int_distribution<int64> node_index_dist{
+      0, (int64)(existing_nodes.size() - 1)};
+  std::minstd_rand0 gen(absl::ToUnixMillis(absl::Now()));
+
+  for (int64 i = 0; i < num_operations_; ++i) {
+    int64 curr_bytes = 0;
+    ReadNodesByPropertiesWorkItemType read_request;
+    switch (read_nodes_by_properties_config_.specification()) {
+      case ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID:
+      case ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID:
+      case ReadNodesByPropertiesConfig::CONTEXTS_BY_ID:
+        TF_RETURN_IF_ERROR(SetUpImplForReadNodesByIds(
+            read_nodes_by_properties_config_, existing_nodes, node_index_dist,
+            gen, read_request, curr_bytes));
+        break;
+      case ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI:
+        TF_RETURN_IF_ERROR(SetUpImplForReadArtifactsByURIs(
+            read_nodes_by_properties_config_, existing_nodes, node_index_dist,
+            gen, read_request, curr_bytes));
+        break;
+      case ReadNodesByPropertiesConfig::ARTIFACTS_BY_TYPE:
+      case ReadNodesByPropertiesConfig::EXECUTIONS_BY_TYPE:
+      case ReadNodesByPropertiesConfig::CONTEXTS_BY_TYPE:
+        TF_RETURN_IF_ERROR(SetUpImplForReadNodesByType(
+            read_nodes_by_properties_config_, existing_nodes, node_index_dist,
+            gen, read_request, curr_bytes));
+        break;
+      case ReadNodesByPropertiesConfig::ARTIFACT_BY_TYPE_AND_NAME:
+      case ReadNodesByPropertiesConfig::EXECUTION_BY_TYPE_AND_NAME:
+      case ReadNodesByPropertiesConfig::CONTEXT_BY_TYPE_AND_NAME:
+        TF_RETURN_IF_ERROR(SetUpImplForReadNodeByTypeAndName(
+            read_nodes_by_properties_config_, existing_nodes, node_index_dist,
+            gen, read_request, curr_bytes));
+        break;
+      default:
+        LOG(FATAL) << "Wrong specification for ReadNodesByProperties!";
+    }
+    work_items_.emplace_back(read_request, curr_bytes);
+  }
+  return tensorflow::Status::OK();
+}
+
+// Executions of work items.
+tensorflow::Status ReadNodesByProperties::RunOpImpl(
+    const int64 work_items_index, MetadataStore* store) {
+  switch (read_nodes_by_properties_config_.specification()) {
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID: {
+      auto request = absl::get<GetArtifactsByIDRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactsByIDResponse response;
+      return store->GetArtifactsByID(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID: {
+      auto request = absl::get<GetExecutionsByIDRequest>(
+          work_items_[work_items_index].first);
+      GetExecutionsByIDResponse response;
+      return store->GetExecutionsByID(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::CONTEXTS_BY_ID: {
+      auto request = absl::get<GetContextsByIDRequest>(
+          work_items_[work_items_index].first);
+      GetContextsByIDResponse response;
+      return store->GetContextsByID(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_TYPE: {
+      auto request = absl::get<GetArtifactsByTypeRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactsByTypeResponse response;
+      return store->GetArtifactsByType(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::EXECUTIONS_BY_TYPE: {
+      auto request = absl::get<GetExecutionsByTypeRequest>(
+          work_items_[work_items_index].first);
+      GetExecutionsByTypeResponse response;
+      return store->GetExecutionsByType(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::CONTEXTS_BY_TYPE: {
+      auto request = absl::get<GetContextsByTypeRequest>(
+          work_items_[work_items_index].first);
+      GetContextsByTypeResponse response;
+      return store->GetContextsByType(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::ARTIFACT_BY_TYPE_AND_NAME: {
+      auto request = absl::get<GetArtifactByTypeAndNameRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactByTypeAndNameResponse response;
+      return store->GetArtifactByTypeAndName(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::EXECUTION_BY_TYPE_AND_NAME: {
+      auto request = absl::get<GetExecutionByTypeAndNameRequest>(
+          work_items_[work_items_index].first);
+      GetExecutionByTypeAndNameResponse response;
+      return store->GetExecutionByTypeAndName(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::CONTEXT_BY_TYPE_AND_NAME: {
+      auto request = absl::get<GetContextByTypeAndNameRequest>(
+          work_items_[work_items_index].first);
+      GetContextByTypeAndNameResponse response;
+      return store->GetContextByTypeAndName(request, &response);
+    }
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI: {
+      auto request = absl::get<GetArtifactsByURIRequest>(
+          work_items_[work_items_index].first);
+      GetArtifactsByURIResponse response;
+      return store->GetArtifactsByURI(request, &response);
+    }
+    default:
+      return tensorflow::errors::InvalidArgument("Wrong specification!");
+  }
+}
+
+tensorflow::Status ReadNodesByProperties::TearDownImpl() {
+  work_items_.clear();
+  return tensorflow::Status::OK();
+}
+
+std::string ReadNodesByProperties::GetName() { return name_; }
+
+}  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.h
+++ b/ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.h
@@ -1,0 +1,86 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef ML_METADATA_TOOLS_MLMD_BENCH_READ_NODES_BY_PROPERTIES_WORKLOAD_H
+#define ML_METADATA_TOOLS_MLMD_BENCH_READ_NODES_BY_PROPERTIES_WORKLOAD_H
+
+#include "absl/types/variant.h"
+#include "ml_metadata/metadata_store/metadata_store.h"
+#include "ml_metadata/metadata_store/types.h"
+#include "ml_metadata/proto/metadata_store_service.pb.h"
+#include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/workload.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace ml_metadata {
+
+// Defines a ReadNodesByPropertiesWorkItemType that can be different requests to
+// look for MLMD nodes by their properties.
+using ReadNodesByPropertiesWorkItemType =
+    absl::variant<GetArtifactsByIDRequest, GetExecutionsByIDRequest,
+                  GetContextsByIDRequest, GetArtifactsByTypeRequest,
+                  GetExecutionsByTypeRequest, GetContextsByTypeRequest,
+                  GetArtifactByTypeAndNameRequest,
+                  GetExecutionByTypeAndNameRequest,
+                  GetContextByTypeAndNameRequest, GetArtifactsByURIRequest>;
+
+// A specific workload for getting nodes: Artifacts / Executions / Contexts by
+// their properties.
+class ReadNodesByProperties
+    : public Workload<ReadNodesByPropertiesWorkItemType> {
+ public:
+  ReadNodesByProperties(
+      const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+      int64 num_operations);
+  ~ReadNodesByProperties() override = default;
+
+ protected:
+  // Specific implementation of SetUpImpl() for ReadNodesByProperties workload
+  // according to its semantic.
+  // A list of work items(ReadNodesByPropertiesWorkItemType) will be generated.
+  // When the API has querying conditions, select from existing nodes properties
+  // w.r.t. the querying parameters to finalize the query string. If the
+  // specification of current workload is ARTIFACTS_BY_ID / EXECUTIONS_BY_ID /
+  // CONTEXTS_BY_ID or ARTIFACTS_BY_URI, the number of ids or uris per request
+  // will be generated w.r.t. the uniform distribution `num_of_parameters`.
+  // Returns detailed error if query executions failed.
+  tensorflow::Status SetUpImpl(MetadataStore* store) final;
+
+  // Specific implementation of RunOpImpl() for ReadNodesByProperties workload
+  // according to its semantic.
+  // Runs the work items(ReadNodesByPropertiesWorkItemType) on the store.
+  // Returns detailed error if query executions failed.
+  tensorflow::Status RunOpImpl(int64 work_items_index,
+                               MetadataStore* store) final;
+
+  // Specific implementation of TearDownImpl() for ReadNodesByProperties
+  // workload according to its semantic. Cleans the work items.
+  tensorflow::Status TearDownImpl() final;
+
+  // Gets the current workload's name, which is used in stats report for this
+  // workload.
+  std::string GetName() final;
+
+ private:
+  // Workload configurations specified by the users.
+  const ReadNodesByPropertiesConfig read_nodes_by_properties_config_;
+  // Number of operations for the current workload.
+  const int64 num_operations_;
+  // String for indicating the name of current workload instance.
+  const std::string name_;
+};
+
+}  // namespace ml_metadata
+
+#endif  // ML_METADATA_TOOLS_MLMD_BENCH_READ_NODES_BY_PROPERTIES_WORKLOAD_H

--- a/ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload_test.cc
+++ b/ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload_test.cc
@@ -1,0 +1,139 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "ml_metadata/tools/mlmd_bench/read_nodes_by_properties_workload.h"
+
+#include <gtest/gtest.h>
+#include "absl/memory/memory.h"
+#include "ml_metadata/metadata_store/metadata_store.h"
+#include "ml_metadata/metadata_store/metadata_store_factory.h"
+#include "ml_metadata/metadata_store/test_util.h"
+#include "ml_metadata/proto/metadata_store.pb.h"
+#include "ml_metadata/proto/metadata_store_service.pb.h"
+#include "ml_metadata/tools/mlmd_bench/proto/mlmd_bench.pb.h"
+#include "ml_metadata/tools/mlmd_bench/util.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+
+namespace ml_metadata {
+namespace {
+
+constexpr int kNumberOfOperations = 100;
+constexpr int kNumberOfExistedTypesInDb = 100;
+constexpr int kNumberOfExistedNodesInDb = 300;
+
+// Enumerates the workload configurations as the test parameters that ensure
+// test coverage.
+std::vector<WorkloadConfig> EnumerateConfigs() {
+  std::vector<WorkloadConfig> configs;
+  std::vector<ReadNodesByPropertiesConfig::Specification> specifications = {
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID,
+      ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID,
+      ReadNodesByPropertiesConfig::CONTEXTS_BY_ID,
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_TYPE,
+      ReadNodesByPropertiesConfig::EXECUTIONS_BY_TYPE,
+      ReadNodesByPropertiesConfig::CONTEXTS_BY_TYPE,
+      ReadNodesByPropertiesConfig::ARTIFACT_BY_TYPE_AND_NAME,
+      ReadNodesByPropertiesConfig::EXECUTION_BY_TYPE_AND_NAME,
+      ReadNodesByPropertiesConfig::CONTEXT_BY_TYPE_AND_NAME,
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI};
+
+  for (const ReadNodesByPropertiesConfig::Specification& specification :
+       specifications) {
+    WorkloadConfig config;
+    config.set_num_operations(kNumberOfOperations);
+    config.mutable_read_nodes_by_properties_config()->set_specification(
+        specification);
+    if (specification == ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID ||
+        specification == ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID ||
+        specification == ReadNodesByPropertiesConfig::CONTEXTS_BY_ID ||
+        specification == ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI) {
+      config.mutable_read_nodes_by_properties_config()
+          ->mutable_num_of_parameters()
+          ->set_minimum(1);
+      config.mutable_read_nodes_by_properties_config()
+          ->mutable_num_of_parameters()
+          ->set_maximum(10);
+    }
+    configs.push_back(config);
+  }
+
+  return configs;
+}
+
+// Test fixture that uses the same data configuration for multiple following
+// parameterized ReadNodesByProperties tests.
+// The parameter here is the specific Workload configuration that contains
+// the ReadNodesByProperties configuration and the number of operations.
+class ReadNodesByPropertiesParameterizedTestFixture
+    : public ::testing::TestWithParam<WorkloadConfig> {
+ protected:
+  void SetUp() override {
+    ConnectionConfig mlmd_config;
+    // Uses a fake in-memory SQLite database for testing.
+    mlmd_config.mutable_fake_database();
+    TF_ASSERT_OK(CreateMetadataStore(mlmd_config, &store_));
+    read_nodes_by_properties_ = absl::make_unique<ReadNodesByProperties>(
+        ReadNodesByProperties(GetParam().read_nodes_by_properties_config(),
+                              GetParam().num_operations()));
+    TF_ASSERT_OK(InsertTypesInDb(
+        /*num_artifact_types=*/kNumberOfExistedTypesInDb,
+        /*num_execution_types=*/kNumberOfExistedTypesInDb,
+        /*num_context_types=*/kNumberOfExistedTypesInDb, *store_));
+
+    TF_ASSERT_OK(InsertNodesInDb(
+        /*num_artifact_nodes=*/kNumberOfExistedNodesInDb,
+        /*num_execution_nodes=*/kNumberOfExistedNodesInDb,
+        /*num_context_nodes=*/kNumberOfExistedNodesInDb, *store_));
+  }
+
+  std::unique_ptr<ReadNodesByProperties> read_nodes_by_properties_;
+  std::unique_ptr<MetadataStore> store_;
+};
+
+// Tests the SetUpImpl() for ReadNodesByProperties. Checks the SetUpImpl()
+// indeed prepares a list of work items whose length is the same as the
+// specified number of operations.
+TEST_P(ReadNodesByPropertiesParameterizedTestFixture, SetUpImplTest) {
+  TF_ASSERT_OK(read_nodes_by_properties_->SetUp(store_.get()));
+  EXPECT_EQ(GetParam().num_operations(),
+            read_nodes_by_properties_->num_operations());
+}
+
+// Tests the RunOpImpl() for ReadNodesByProperties. Checks indeed all the work
+// items have been executed and some bytes are transferred during the reading
+// process.
+TEST_P(ReadNodesByPropertiesParameterizedTestFixture, RunOpImplTest) {
+  TF_ASSERT_OK(read_nodes_by_properties_->SetUp(store_.get()));
+
+  int64 total_done = 0;
+  ThreadStats stats;
+  stats.Start();
+  for (int64 i = 0; i < read_nodes_by_properties_->num_operations(); ++i) {
+    OpStats op_stats;
+    TF_ASSERT_OK(read_nodes_by_properties_->RunOp(i, store_.get(), op_stats));
+    stats.Update(op_stats, total_done);
+  }
+  stats.Stop();
+  EXPECT_EQ(stats.done(), GetParam().num_operations());
+  // Checks that the transferred bytes is greater that 0(the reading process
+  // indeed occurred).
+  EXPECT_GT(stats.bytes(), 0);
+}
+
+INSTANTIATE_TEST_CASE_P(ReadNodesByPropertiesTest,
+                        ReadNodesByPropertiesParameterizedTestFixture,
+                        ::testing::ValuesIn(EnumerateConfigs()));
+
+}  // namespace
+}  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/read_types_workload.h
+++ b/ml_metadata/tools/mlmd_bench/read_types_workload.h
@@ -72,7 +72,7 @@ class ReadTypes : public Workload<ReadTypesWorkItemType> {
   // Number of operations for the current workload.
   const int64 num_operations_;
   // String for indicating the name of current workload instance.
-  std::string name_;
+  const std::string name_;
 };
 
 }  // namespace ml_metadata

--- a/ml_metadata/tools/mlmd_bench/util.cc
+++ b/ml_metadata/tools/mlmd_bench/util.cc
@@ -247,6 +247,29 @@ tensorflow::Status GetExistingNodes(
   return tensorflow::Status::OK();
 }
 
+tensorflow::Status GetExistingNodes(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    MetadataStore& store, std::vector<Node>& existing_nodes) {
+  switch (read_nodes_by_properties_config.specification()) {
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID:
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_TYPE:
+    case ReadNodesByPropertiesConfig::ARTIFACT_BY_TYPE_AND_NAME:
+    case ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI:
+      return GetExistingNodesImpl(FetchArtifact, store, existing_nodes);
+    case ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID:
+    case ReadNodesByPropertiesConfig::EXECUTIONS_BY_TYPE:
+    case ReadNodesByPropertiesConfig::EXECUTION_BY_TYPE_AND_NAME:
+      return GetExistingNodesImpl(FetchExecution, store, existing_nodes);
+    case ReadNodesByPropertiesConfig::CONTEXTS_BY_ID:
+    case ReadNodesByPropertiesConfig::CONTEXTS_BY_TYPE:
+    case ReadNodesByPropertiesConfig::CONTEXT_BY_TYPE_AND_NAME:
+      return GetExistingNodesImpl(FetchContext, store, existing_nodes);
+    default:
+      LOG(FATAL) << "Unknown ReadNodesByPropertiesConfig specification.";
+  }
+  return tensorflow::Status::OK();
+}
+
 tensorflow::Status InsertTypesInDb(const int64 num_artifact_types,
                                    const int64 num_execution_types,
                                    const int64 num_context_types,

--- a/ml_metadata/tools/mlmd_bench/util.h
+++ b/ml_metadata/tools/mlmd_bench/util.h
@@ -76,6 +76,13 @@ tensorflow::Status GetExistingNodes(
     std::vector<Node>& existing_artifact_nodes,
     std::vector<Node>& existing_execution_nodes);
 
+// Gets all the existing nodes inside db and store them into `existing_nodes`
+// given `read_nodes_by_properties_config`. Returns detailed error if query
+// executions failed.
+tensorflow::Status GetExistingNodes(
+    const ReadNodesByPropertiesConfig& read_nodes_by_properties_config,
+    MetadataStore& store, std::vector<Node>& existing_nodes);
+
 // Inserts some types into db for setting up in testing. Returns detailed error
 // if query executions failed.
 tensorflow::Status InsertTypesInDb(int64 num_artifact_types,

--- a/ml_metadata/tools/mlmd_bench/util_test.cc
+++ b/ml_metadata/tools/mlmd_bench/util_test.cc
@@ -323,5 +323,50 @@ TEST(UtilGetTest, GetNodesWithFillEventsConfigTest) {
   EXPECT_EQ(kNumberOfInsertedExecutions, existing_execution_nodes.size());
 }
 
+// Tests GetExistingNodes() with ReadNodesByPropertiesConfig as input.
+TEST(UtilGetTest, GetNodesWithReadNodesByPropertiesConfigTest) {
+  std::unique_ptr<MetadataStore> store;
+  ConnectionConfig mlmd_config;
+  // Uses a fake in-memory SQLite database for testing.
+  mlmd_config.mutable_fake_database();
+  TF_ASSERT_OK(CreateMetadataStore(mlmd_config, &store));
+  TF_ASSERT_OK(InsertTypesInDb(
+      /*num_artifact_types=*/kNumberOfInsertedArtifactTypes,
+      /*num_execution_types=*/kNumberOfInsertedExecutionTypes,
+      /*num_context_types=*/kNumberOfInsertedContextTypes, *store));
+  TF_ASSERT_OK(InsertNodesInDb(
+      /*num_artifact_nodes=*/kNumberOfInsertedArtifacts,
+      /*num_execution_nodes=*/kNumberOfInsertedExecutions,
+      /*num_context_nodes=*/kNumberOfInsertedContexts, *store));
+
+  std::vector<ReadNodesByPropertiesConfig::Specification> specification{
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_ID,
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_TYPE,
+      ReadNodesByPropertiesConfig::ARTIFACT_BY_TYPE_AND_NAME,
+      ReadNodesByPropertiesConfig::ARTIFACTS_BY_URI,
+      ReadNodesByPropertiesConfig::EXECUTIONS_BY_ID,
+      ReadNodesByPropertiesConfig::EXECUTIONS_BY_TYPE,
+      ReadNodesByPropertiesConfig::EXECUTION_BY_TYPE_AND_NAME,
+      ReadNodesByPropertiesConfig::CONTEXTS_BY_ID,
+      ReadNodesByPropertiesConfig::CONTEXTS_BY_TYPE,
+      ReadNodesByPropertiesConfig::CONTEXT_BY_TYPE_AND_NAME};
+
+  std::vector<int> size{
+      kNumberOfInsertedArtifacts,  kNumberOfInsertedArtifacts,
+      kNumberOfInsertedArtifacts,  kNumberOfInsertedArtifacts,
+      kNumberOfInsertedExecutions, kNumberOfInsertedExecutions,
+      kNumberOfInsertedExecutions, kNumberOfInsertedContexts,
+      kNumberOfInsertedContexts,   kNumberOfInsertedContexts};
+
+  for (int i = 0; i < size.size(); ++i) {
+    std::vector<Node> exisiting_nodes;
+    ReadNodesByPropertiesConfig read_nodes_by_properties_config;
+    read_nodes_by_properties_config.set_specification(specification[i]);
+    TF_ASSERT_OK(GetExistingNodes(read_nodes_by_properties_config, *store,
+                                  exisiting_nodes));
+    EXPECT_THAT(exisiting_nodes, ::testing::SizeIs(size[i]));
+  }
+}  // namespace
+
 }  // namespace
 }  // namespace ml_metadata


### PR DESCRIPTION
Supports benchmarking the performance of GetArtifactsByID(), GetExecutionsByID(), GetContextsByID(), GetArtifactsByType(), GetExecutionsByType(), GetContextsByType(), GetArtifactByTypeAndName(), GetExecutionByTypeAndName(), GetContextByTypeAndName() and GetArtifactsByURI() APIs.