### PR TITLE
Update GetExecutionsByContext and GetArtifactsByContext to support pagination

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,38 @@
+<<<<<<< HEAD
+=======
+# Current version (not yet released; still in development)
+
+## Major Features and Improvements
+
+*   Adds `reuse_context_if_already_exist` option to `put_execution` python API
+    to better support concurrent execution publishing with the same new context.
+
+
+## Bug Fixes and Other Changes
+
+## Breaking changes
+
+## Deprecations
+
+# Release 0.25.1
+
+## Major Features and Improvements
+
+*   Supports pagination and ordering options in GetExecutionsByContext and
+    GetArtifactsByContext APIs.
+
+## Bug Fixes and Other Changes
+
+*   N/A
+
+## Breaking changes
+
+*   N/A
+
+## Deprecations
+
+*   N/A
+
 # Release 0.25.0
 
 ## Major Features and Improvements

--- a/ml_metadata/metadata_store/BUILD
+++ b/ml_metadata/metadata_store/BUILD
@@ -38,11 +38,7 @@ cc_library(
     ],
     deps = [
         ":metadata_source",
-        "@com_google_protobuf//:protobuf",
-        
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "//ml_metadata/proto:metadata_source_proto",
         "//ml_metadata/proto:metadata_store_proto",
@@ -66,7 +62,6 @@ cc_library(
         "rdbms_metadata_access_object.h",
     ],
     deps = [
-        ":constants",
         ":list_operation_util",
         ":metadata_access_object_base",
         ":metadata_source",
@@ -77,6 +72,7 @@ cc_library(
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:optional",
         "//ml_metadata/proto:metadata_source_proto",
         "//ml_metadata/proto:metadata_store_proto",
         "@org_tensorflow//tensorflow/core:lib",
@@ -179,6 +175,7 @@ cc_library(
         ":query_config_executor",
         ":rdbms_metadata_access_object",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "//ml_metadata/proto:metadata_source_proto",
         "//ml_metadata/proto:metadata_store_proto",
@@ -254,6 +251,7 @@ cc_library(
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/types:optional",
         "//ml_metadata/proto:metadata_store_proto",
         "//ml_metadata/proto:metadata_store_service_proto",
         "@org_tensorflow//tensorflow/core:lib",
@@ -308,6 +306,7 @@ cc_library(
     ],
     deps = [
         ":types",
+        "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "//ml_metadata/proto:metadata_source_proto",
         "//ml_metadata/proto:metadata_store_proto",

--- a/ml_metadata/metadata_store/list_operation_query_helper.cc
+++ b/ml_metadata/metadata_store/list_operation_query_helper.cc
@@ -107,8 +107,8 @@ tensorflow::Status AppendLimitClause(const ListOperationOptions& options,
                      options.max_result_size()));
   }
 
-  const int max_result_size =
-      std::min(options.max_result_size(), kDefaultMaxListOperationResultSize);
+  const int max_result_size = std::min(options.max_result_size(),
+                                       kDefaultMaxListOperationResultSize + 1);
   absl::SubstituteAndAppend(&sql_query_clause, " LIMIT $0 ", max_result_size);
   return tensorflow::Status::OK();
 }

--- a/ml_metadata/metadata_store/list_operation_query_helper_test.cc
+++ b/ml_metadata/metadata_store/list_operation_query_helper_test.cc
@@ -106,7 +106,7 @@ TEST(ListOperationQueryHelperTest, LimitOverMaxClause) {
   options.set_max_result_size(200);
   std::string limit_clause;
   TF_ASSERT_OK(AppendLimitClause(options, limit_clause));
-  EXPECT_EQ(limit_clause, " LIMIT 100 ");
+  EXPECT_EQ(limit_clause, " LIMIT 101 ");
 }
 
 TEST(ListOperationQueryHelperTest, InvalidLimit) {
@@ -116,6 +116,5 @@ TEST(ListOperationQueryHelperTest, InvalidLimit) {
   EXPECT_EQ(AppendLimitClause(options, limit_clause).code(),
             tensorflow::error::INVALID_ARGUMENT);
 }
-
 }  // namespace
 }  // namespace ml_metadata

--- a/ml_metadata/metadata_store/metadata_access_object.h
+++ b/ml_metadata/metadata_store/metadata_access_object.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <memory>
 #include <vector>
 
+#include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "ml_metadata/metadata_store/metadata_source.h"
 #include "ml_metadata/proto/metadata_source.pb.h"
@@ -382,6 +383,12 @@ class MetadataAccessObject {
   virtual tensorflow::Status FindExecutionsByContext(
       int64 context_id, std::vector<Execution>* executions) = 0;
 
+  // Queries the executions associated with a context_id.
+  // Returns INVALID_ARGUMENT error, if the `executions` is null.
+  virtual tensorflow::Status FindExecutionsByContext(
+      int64 context_id, absl::optional<ListOperationOptions> list_options,
+      std::vector<Execution>* executions, std::string* next_page_token) = 0;
+
   // Creates an attribution, returns the assigned attribution id.
   // Returns INVALID_ARGUMENT error, if no context matches the context_id.
   // Returns INVALID_ARGUMENT error, if no artifact matches the artifact_id.
@@ -399,6 +406,36 @@ class MetadataAccessObject {
   virtual tensorflow::Status FindArtifactsByContext(
       int64 context_id, std::vector<Artifact>* artifacts) = 0;
 
+<<<<<<< HEAD
+=======
+  // Queries the artifacts attributed to a context_id.
+  // If `list_options` is specified then results are paginated based on the
+  // fields set in `list_options`.
+  // Returns INVALID_ARGUMENT error, if the `artifacts` is null.
+  virtual tensorflow::Status FindArtifactsByContext(
+      int64 context_id, absl::optional<ListOperationOptions> list_options,
+      std::vector<Artifact>* artifacts, std::string* next_page_token) = 0;
+
+  // Creates a parent context, returns OK if succeeds.
+  // Returns INVALID_ARGUMENT error, if no context matches the child_id.
+  // Returns INVALID_ARGUMENT error, if no context matches the parent_id.
+  // Returns ALREADY_EXISTS error, if the same parent context already exists.
+  // TODO(b/155207795) Consider ParentContext transitive closure check when
+  // inserting a new record.
+  virtual tensorflow::Status CreateParentContext(
+      const ParentContext& parent_context) = 0;
+
+  // Queries the parent-contexts of a context_id.
+  // Returns INVALID_ARGUMENT error, if the `contexts` is null.
+  virtual tensorflow::Status FindParentContextsByContextId(
+      int64 context_id, std::vector<Context>* contexts) = 0;
+
+  // Queries the child-contexts of a context_id.
+  // Returns INVALID_ARGUMENT error, if the `contexts` is null.
+  virtual tensorflow::Status FindChildContextsByContextId(
+      int64 context_id, std::vector<Context>* contexts) = 0;
+
+>>>>>>> 15ed9f7 (Update GetExecutionsByContext and GetArtifactsByContext to support pagination and ordering results by ID, create time and last update time fields.)
   // Resolves the schema version stored in the metadata source. The `db_version`
   // is set to 0, if it is a 0.13.2 release pre-existing database.
   // Returns DATA_LOSS error, if schema version info table exists but its value

--- a/ml_metadata/metadata_store/metadata_access_object_test.cc
+++ b/ml_metadata/metadata_store/metadata_access_object_test.cc
@@ -2572,6 +2572,143 @@ TEST_P(MetadataAccessObjectTest, CreateAndUseAssociation) {
   EXPECT_EQ(got_artifacts.size(), 0);
 }
 
+TEST_P(MetadataAccessObjectTest, GetAssociationUsingPagination) {
+  TF_ASSERT_OK(Init());
+  int64 execution_type_id = InsertType<ExecutionType>("execution_type");
+  int64 context_type_id = InsertType<ContextType>("context_type");
+  Execution execution1;
+  execution1.set_type_id(execution_type_id);
+  (*execution1.mutable_custom_properties())["custom"].set_int_value(3);
+  Execution execution2;
+  execution2.set_type_id(execution_type_id);
+  (*execution2.mutable_custom_properties())["custom"].set_int_value(5);
+
+  Context context = ParseTextProtoOrDie<Context>("name: 'context_instance'");
+  context.set_type_id(context_type_id);
+
+  int64 execution_id_1, execution_id_2, context_id;
+  TF_ASSERT_OK(
+      metadata_access_object_->CreateExecution(execution1, &execution_id_1));
+  execution1.set_id(execution_id_1);
+  TF_ASSERT_OK(
+      metadata_access_object_->CreateExecution(execution2, &execution_id_2));
+  execution2.set_id(execution_id_2);
+
+  TF_ASSERT_OK(metadata_access_object_->CreateContext(context, &context_id));
+  context.set_id(context_id);
+
+  Association association1;
+  association1.set_execution_id(execution_id_1);
+  association1.set_context_id(context_id);
+
+  Association association2;
+  association2.set_execution_id(execution_id_2);
+  association2.set_context_id(context_id);
+
+  int64 association_id_1;
+  TF_EXPECT_OK(metadata_access_object_->CreateAssociation(association1,
+                                                          &association_id_1));
+  int64 association_id_2;
+  TF_EXPECT_OK(metadata_access_object_->CreateAssociation(association2,
+                                                          &association_id_2));
+
+  ListOperationOptions list_options =
+      ParseTextProtoOrDie<ListOperationOptions>(R"(
+        max_result_size: 1,
+        order_by_field: { field: CREATE_TIME is_asc: false }
+      )");
+
+  std::string next_page_token;
+  std::vector<Execution> got_executions;
+  TF_EXPECT_OK(metadata_access_object_->FindExecutionsByContext(
+      context_id, list_options, &got_executions, &next_page_token));
+  EXPECT_THAT(got_executions, SizeIs(1));
+  EXPECT_THAT(execution2, EqualsProto(got_executions[0], /*ignore_fields=*/{
+                                          "create_time_since_epoch",
+                                          "last_update_time_since_epoch"}));
+  ASSERT_FALSE(next_page_token.empty());
+
+  list_options.set_next_page_token(next_page_token);
+  got_executions.clear();
+  TF_EXPECT_OK(metadata_access_object_->FindExecutionsByContext(
+      context_id, list_options, &got_executions, &next_page_token));
+  EXPECT_THAT(got_executions, SizeIs(1));
+  EXPECT_THAT(execution1, EqualsProto(got_executions[0], /*ignore_fields=*/{
+                                          "create_time_since_epoch",
+                                          "last_update_time_since_epoch"}));
+  ASSERT_TRUE(next_page_token.empty());
+}
+
+TEST_P(MetadataAccessObjectTest, GetAttributionUsingPagination) {
+  TF_ASSERT_OK(Init());
+  int64 artifact_type_id = InsertType<ArtifactType>("artifact_type");
+  int64 context_type_id = InsertType<ContextType>("context_type");
+  Artifact artifact1;
+  artifact1.set_uri("http://some_uri");
+  artifact1.set_type_id(artifact_type_id);
+  (*artifact1.mutable_custom_properties())["custom"].set_int_value(3);
+
+  Artifact artifact2;
+  artifact2.set_uri("http://some_uri");
+  artifact2.set_type_id(artifact_type_id);
+  (*artifact2.mutable_custom_properties())["custom"].set_int_value(5);
+
+  Context context = ParseTextProtoOrDie<Context>("name: 'context_instance'");
+  context.set_type_id(context_type_id);
+
+  int64 artifact_id_1, artifact_id_2, context_id;
+  TF_ASSERT_OK(
+      metadata_access_object_->CreateArtifact(artifact1, &artifact_id_1));
+  artifact1.set_id(artifact_id_1);
+  TF_ASSERT_OK(
+      metadata_access_object_->CreateArtifact(artifact2, &artifact_id_2));
+  artifact2.set_id(artifact_id_2);
+
+  TF_ASSERT_OK(metadata_access_object_->CreateContext(context, &context_id));
+  context.set_id(context_id);
+
+  Attribution attribution1;
+  attribution1.set_artifact_id(artifact_id_1);
+  attribution1.set_context_id(context_id);
+
+  Attribution attribution2;
+  attribution2.set_artifact_id(artifact_id_2);
+  attribution2.set_context_id(context_id);
+
+  int64 attribution_id_1;
+  TF_EXPECT_OK(metadata_access_object_->CreateAttribution(attribution1,
+                                                          &attribution_id_1));
+  int64 attribution_id_2;
+  TF_EXPECT_OK(metadata_access_object_->CreateAttribution(attribution2,
+                                                          &attribution_id_2));
+
+  ListOperationOptions list_options =
+      ParseTextProtoOrDie<ListOperationOptions>(R"(
+        max_result_size: 1,
+        order_by_field: { field: CREATE_TIME is_asc: false }
+      )");
+
+  std::string next_page_token;
+  std::vector<Artifact> got_artifacts;
+  TF_EXPECT_OK(metadata_access_object_->FindArtifactsByContext(
+      context_id, list_options, &got_artifacts, &next_page_token));
+  EXPECT_THAT(got_artifacts, SizeIs(1));
+  EXPECT_THAT(artifact2, EqualsProto(got_artifacts[0], /*ignore_fields=*/{
+                                         "create_time_since_epoch",
+                                         "last_update_time_since_epoch"}));
+  ASSERT_FALSE(next_page_token.empty());
+
+  got_artifacts.clear();
+  list_options.set_next_page_token(next_page_token);
+  TF_EXPECT_OK(metadata_access_object_->FindArtifactsByContext(
+      context_id, list_options, &got_artifacts, &next_page_token));
+  EXPECT_THAT(got_artifacts, SizeIs(1));
+  ASSERT_TRUE(next_page_token.empty());
+  EXPECT_THAT(artifact1, EqualsProto(got_artifacts[0], /*ignore_fields=*/{
+                                         "create_time_since_epoch",
+                                         "last_update_time_since_epoch"}));
+}
+
 TEST_P(MetadataAccessObjectTest, CreateAssociationError) {
   TF_ASSERT_OK(Init());
   Association association;

--- a/ml_metadata/metadata_store/metadata_store.cc
+++ b/ml_metadata/metadata_store/metadata_store.cc
@@ -21,7 +21,9 @@ limitations under the License.
 #include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/memory/memory.h"
+#include "absl/types/optional.h"
 #include "ml_metadata/metadata_store/metadata_access_object_factory.h"
+#include "ml_metadata/proto/metadata_store.pb.h"
 #include "ml_metadata/proto/metadata_store_service.pb.h"
 #include "tensorflow/core/lib/core/errors.h"
 
@@ -1186,11 +1188,22 @@ tensorflow::Status MetadataStore::GetArtifactsByContext(
       [this, &request, &response]() -> tensorflow::Status {
         response->Clear();
         std::vector<Artifact> artifacts;
+        tensorflow::Status status;
+        std::string next_page_token;
+        auto list_options = request.has_options()
+                                ? absl::make_optional(request.options())
+                                : absl::nullopt;
         TF_RETURN_IF_ERROR(metadata_access_object_->FindArtifactsByContext(
-            request.context_id(), &artifacts));
+            request.context_id(), list_options, &artifacts, &next_page_token));
+
         for (const Artifact& artifact : artifacts) {
           *response->mutable_artifacts()->Add() = artifact;
         }
+
+        if (!next_page_token.empty()) {
+          response->set_next_page_token(next_page_token);
+        }
+
         return tensorflow::Status::OK();
       });
 }
@@ -1202,11 +1215,23 @@ tensorflow::Status MetadataStore::GetExecutionsByContext(
       [this, &request, &response]() -> tensorflow::Status {
         response->Clear();
         std::vector<Execution> executions;
+        tensorflow::Status status;
+        std::string next_page_token;
+        auto list_options = request.has_options()
+                                ? absl::make_optional(request.options())
+                                : absl::nullopt;
+
         TF_RETURN_IF_ERROR(metadata_access_object_->FindExecutionsByContext(
-            request.context_id(), &executions));
+            request.context_id(), list_options, &executions, &next_page_token));
+
         for (const Execution& execution : executions) {
           *response->mutable_executions()->Add() = execution;
         }
+
+        if (!next_page_token.empty()) {
+          response->set_next_page_token(next_page_token);
+        }
+
         return tensorflow::Status::OK();
       });
 }

--- a/ml_metadata/metadata_store/metadata_store.h
+++ b/ml_metadata/metadata_store/metadata_store.h
@@ -372,13 +372,15 @@ class MetadataStore : public MetadataStoreServiceInterface {
       const GetContextsByExecutionRequest& request,
       GetContextsByExecutionResponse* response) override;
 
-  // Gets all direct artifacts that a context attributes to.
+  // Gets all direct artifacts using list options that a context attributes to.
+  // If option is not set in the request, then all artifacts are returned.
   // Returns detailed INTERNAL error, if query execution fails.
   tensorflow::Status GetArtifactsByContext(
       const GetArtifactsByContextRequest& request,
       GetArtifactsByContextResponse* response) override;
 
-  // Gets all direct executions that a context associates with.
+  // Gets direct executions using list options that a context associates with.
+  // If option is not set in the request, then all executions are returned.
   // Returns detailed INTERNAL error, if query execution fails.
   tensorflow::Status GetExecutionsByContext(
       const GetExecutionsByContextRequest& request,

--- a/ml_metadata/metadata_store/metadata_store.py
+++ b/ml_metadata/metadata_store/metadata_store.py
@@ -1062,12 +1062,23 @@ class MetadataStore(object):
     """
     request = metadata_store_service_pb2.GetArtifactsByContextRequest()
     request.context_id = context_id
-    response = metadata_store_service_pb2.GetArtifactsByContextResponse()
+    request.options.max_result_size = 100
+    request.options.order_by_field.field = (
+        metadata_store_pb2.ListOperationOptions.OrderByField.Field.CREATE_TIME)
+    request.options.order_by_field.is_asc = False
 
-    self._call('GetArtifactsByContext', request, response)
     result = []
-    for x in response.artifacts:
-      result.append(x)
+    while True:
+      response = metadata_store_service_pb2.GetArtifactsByContextResponse()
+      self._call('GetArtifactsByContext', request, response)
+      for x in response.artifacts:
+        result.append(x)
+
+      if not response.next_page_token:
+        break
+
+      request.options.next_page_token = response.next_page_token
+
     return result
 
   def get_executions_by_context(
@@ -1082,12 +1093,23 @@ class MetadataStore(object):
     """
     request = metadata_store_service_pb2.GetExecutionsByContextRequest()
     request.context_id = context_id
-    response = metadata_store_service_pb2.GetExecutionsByContextResponse()
+    request.options.max_result_size = 100
+    request.options.order_by_field.field = (
+        metadata_store_pb2.ListOperationOptions.OrderByField.Field.CREATE_TIME)
+    request.options.order_by_field.is_asc = False
 
-    self._call('GetExecutionsByContext', request, response)
     result = []
-    for x in response.executions:
-      result.append(x)
+    while True:
+      response = metadata_store_service_pb2.GetExecutionsByContextResponse()
+      self._call('GetExecutionsByContext', request, response)
+      for x in response.executions:
+        result.append(x)
+
+      if not response.next_page_token:
+        break
+
+      request.options.next_page_token = response.next_page_token
+
     return result
 
   def get_events_by_execution_ids(

--- a/ml_metadata/metadata_store/metadata_store_test.py
+++ b/ml_metadata/metadata_store/metadata_store_test.py
@@ -890,6 +890,135 @@ class MetadataStoreTest(parameterized.TestCase):
     artifacts_by_context = store.get_artifacts_by_context(context_ids[0])
     self.assertLen(artifacts_by_context, 2)
 
+<<<<<<< HEAD
+=======
+  def test_get_executions_by_context_with_pagination(self):
+    store = _get_metadata_store()
+    execution_type = metadata_store_pb2.ExecutionType(
+        name=self._get_test_type_name())
+    execution_type_id = store.put_execution_type(execution_type)
+
+    context_type = metadata_store_pb2.ContextType(
+        name=self._get_test_type_name())
+    context_type_id = store.put_context_type(context_type)
+    context = metadata_store_pb2.Context(
+        type_id=context_type_id, name=self._get_test_type_name())
+    context_ids = store.put_contexts([context])
+    context_id = context_ids[0]
+
+    executions = []
+    count = 0
+    while count < 102:
+      execution = metadata_store_pb2.Execution(type_id=execution_type_id)
+      executions.append(execution)
+      count += 1
+
+    execution_ids = store.put_executions(executions)
+
+    associations = []
+    count = 0
+    for execution_id in execution_ids:
+      association = metadata_store_pb2.Association(
+          context_id=context_id, execution_id=execution_id)
+      associations.append(association)
+
+    store.put_attributions_and_associations([], associations)
+
+    got_executions = store.get_executions_by_context(context_id)
+    reverse_index = len(execution_ids) - 1
+    for got_execution in got_executions:
+      self.assertEqual(got_execution.id, execution_ids[reverse_index])
+      reverse_index -= 1
+
+    self.assertEqual(reverse_index, -1)
+
+  def test_get_artifacts_by_context_with_pagination(self):
+    store = _get_metadata_store()
+    artifact_type = metadata_store_pb2.ArtifactType(
+        name=self._get_test_type_name())
+    artifact_type_id = store.put_artifact_type(artifact_type)
+
+    context_type = metadata_store_pb2.ContextType(
+        name=self._get_test_type_name())
+    context_type_id = store.put_context_type(context_type)
+    context = metadata_store_pb2.Context(
+        type_id=context_type_id, name=self._get_test_type_name())
+    context_ids = store.put_contexts([context])
+    context_id = context_ids[0]
+
+    artifacts = []
+    count = 0
+    while count < 102:
+      artifact = metadata_store_pb2.Artifact(type_id=artifact_type_id)
+      artifacts.append(artifact)
+      count += 1
+
+    artifact_ids = store.put_artifacts(artifacts)
+
+    attributions = []
+    count = 0
+    for artifact_id in artifact_ids:
+      attribution = metadata_store_pb2.Attribution(
+          context_id=context_id, artifact_id=artifact_id)
+      attributions.append(attribution)
+
+    store.put_attributions_and_associations(attributions, [])
+
+    got_artifacts = store.get_artifacts_by_context(context_id)
+    reverse_index = len(artifact_ids) - 1
+    for got_artifact in got_artifacts:
+      self.assertEqual(got_artifact.id, artifact_ids[reverse_index])
+      reverse_index -= 1
+
+    self.assertEqual(reverse_index, -1)
+
+  def test_put_execution_with_reuse_context_if_already_exist(self):
+    store = _get_metadata_store()
+    execution_type = metadata_store_pb2.ExecutionType(
+        name=self._get_test_type_name())
+    execution_type_id = store.put_execution_type(execution_type)
+    execution = metadata_store_pb2.Execution(type_id=execution_type_id)
+
+    context_type = metadata_store_pb2.ContextType(
+        name=self._get_test_type_name())
+    context_type_id = store.put_context_type(context_type)
+    context = metadata_store_pb2.Context(
+        type_id=context_type_id, name=self._get_test_type_name())
+
+    # mimic a race with calls to create new context with the same name
+    execution_id, _, context_ids = store.put_execution(
+        execution=execution, artifact_and_events=[], contexts=[context])
+
+    # the second call fails due to the context of the same name AlreadyExists
+    with self.assertRaises(errors.AlreadyExistsError):
+      store.put_execution(
+          execution=execution, artifact_and_events=[], contexts=[context])
+
+    # if set reuse_context_if_already_exist, the same call succeeds
+    # context ids are the same, and the execution ids are different.
+    execution_id2, _, context_ids2 = store.put_execution(
+        execution=execution,
+        artifact_and_events=[],
+        contexts=[context],
+        reuse_context_if_already_exist=True)
+    self.assertEqual(context_ids, context_ids2)
+    self.assertNotEqual(execution_id, execution_id2)
+    self.assertLen(store.get_executions_by_context(context_ids[0]), 2)
+
+  def test_put_execution_with_invalid_argument_errors(self):
+    store = _get_metadata_store()
+    execution_type = metadata_store_pb2.ExecutionType(
+        name=self._get_test_type_name())
+    execution_type_id = store.put_execution_type(execution_type)
+    not_exist_id = 1000
+    execution = metadata_store_pb2.Execution(
+        id=not_exist_id, type_id=execution_type_id)
+
+    with self.assertRaises(errors.InvalidArgumentError):
+      store.put_execution(
+          execution=execution, artifact_and_events=[], contexts=[])
+
+>>>>>>> 15ed9f7 (Update GetExecutionsByContext and GetArtifactsByContext to support pagination and ordering results by ID, create time and last update time fields.)
   def test_put_context_type_get_context_type(self):
     store = _get_metadata_store()
     context_type_name = self._get_test_type_name()

--- a/ml_metadata/metadata_store/query_config_executor.cc
+++ b/ml_metadata/metadata_store/query_config_executor.cc
@@ -478,7 +478,8 @@ tensorflow::Status QueryConfigExecutor::InsertExecutionType(
 
 template <typename Node>
 tensorflow::Status QueryConfigExecutor::ListNodeIDsUsingOptions(
-    const ListOperationOptions& options, RecordSet* record_set) {
+    const ListOperationOptions& options,
+    const absl::Span<const int64> candidate_ids, RecordSet* record_set) {
   int64 id_offset, field_offset;
   if (!options.next_page_token().empty()) {
     ListOperationNextPageToken next_page_token;
@@ -503,6 +504,12 @@ tensorflow::Status QueryConfigExecutor::ListNodeIDsUsingOptions(
     return tensorflow::errors::InvalidArgument(
         "Invalid Node passed to ListNodeIDsUsingOptions");
   }
+
+  if (!candidate_ids.empty()) {
+    absl::SubstituteAndAppend(&sql_query, " `id` IN ($0) AND ",
+                              Bind(candidate_ids));
+  }
+
   TF_RETURN_IF_ERROR(AppendOrderingThresholdClause(options, id_offset,
                                                    field_offset, sql_query));
   TF_RETURN_IF_ERROR(AppendOrderByClause(options, sql_query));
@@ -511,18 +518,21 @@ tensorflow::Status QueryConfigExecutor::ListNodeIDsUsingOptions(
 }
 
 tensorflow::Status QueryConfigExecutor::ListArtifactIDsUsingOptions(
-    const ListOperationOptions& options, RecordSet* record_set) {
-  return ListNodeIDsUsingOptions<Artifact>(options, record_set);
+    const ListOperationOptions& options,
+    const absl::Span<const int64> candidate_ids, RecordSet* record_set) {
+  return ListNodeIDsUsingOptions<Artifact>(options, candidate_ids, record_set);
 }
 
 tensorflow::Status QueryConfigExecutor::ListExecutionIDsUsingOptions(
-    const ListOperationOptions& options, RecordSet* record_set) {
-  return ListNodeIDsUsingOptions<Execution>(options, record_set);
+    const ListOperationOptions& options,
+    const absl::Span<const int64> candidate_ids, RecordSet* record_set) {
+  return ListNodeIDsUsingOptions<Execution>(options, candidate_ids, record_set);
 }
 
 tensorflow::Status QueryConfigExecutor::ListContextIDsUsingOptions(
-    const ListOperationOptions& options, RecordSet* record_set) {
-  return ListNodeIDsUsingOptions<Context>(options, record_set);
+    const ListOperationOptions& options,
+    const absl::Span<const int64> candidate_ids, RecordSet* record_set) {
+  return ListNodeIDsUsingOptions<Context>(options, candidate_ids, record_set);
 }
 
 

--- a/ml_metadata/metadata_store/query_config_executor.h
+++ b/ml_metadata/metadata_store/query_config_executor.h
@@ -502,13 +502,16 @@ class QueryConfigExecutor : public QueryExecutor {
       const int64 to_schema_version) final;
 
   tensorflow::Status ListArtifactIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set) final;
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set) final;
 
   tensorflow::Status ListExecutionIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set) final;
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set) final;
 
   tensorflow::Status ListContextIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set) final;
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set) final;
 
 
  private:
@@ -649,12 +652,15 @@ class QueryConfigExecutor : public QueryExecutor {
   // TODO(martinz): consider promoting to MetadataAccessObject.
   tensorflow::Status UpgradeMetadataSourceIfOutOfDate(bool enable_migration);
 
-  // List Node IDs using `options`. Template parameter `Node` specifies the
-  // table to use for listing.
+  // List Node IDs using `options` and `candidate_ids`. Template parameter
+  // `Node` specifies the table to use for listing. If `candidate_ids` is not
+  // empty then result set is constructed using only ids specified in
+  // `candidate_ids`.
   // On success `record_set` is updated with Node IDs.
   template <typename Node>
   tensorflow::Status ListNodeIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set);
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set);
 
   MetadataSourceQueryConfig query_config_;
 

--- a/ml_metadata/metadata_store/query_executor.h
+++ b/ml_metadata/metadata_store/query_executor.h
@@ -462,24 +462,29 @@ class QueryExecutor {
   // Returns a list of IDs.
   virtual tensorflow::Status SelectAllContextIDs(RecordSet* set) = 0;
 
-  // List Artifact IDs using `options`.
-  // On success `record_set` is updated with artifact IDs based on `options`
+  // List Artifact IDs using `options`. If `candidate_ids` is not empty, then
+  // returned result is only built using ids in the `candidate_ids`. On success
+  // `record_set` is updated with artifact IDs based on `options`
   virtual tensorflow::Status ListArtifactIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set) = 0;
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set) = 0;
 
-  // List Execution IDs using `options`.
-  // On success `set` is updated with execution IDs based on `options` and
+  // List Execution IDs using `options`. If `candidate_ids` is not empty, then
+  // returned result is only built using ids in the `candidate_ids`. On success
+  // `set` is updated with execution IDs based on `options` and
   // `next_page_token` is updated with information for the caller to use for
   // next page of results.
   virtual tensorflow::Status ListExecutionIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set) = 0;
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set) = 0;
 
-  // List Context IDs using `options`.
-  // On success `set` is updated with context IDs based on `options` and
-  // `next_page_token` is updated with information for the caller to use for
-  // next page of results.
+  // List Context IDs using `options`. If `candidate_ids` is not empty, then
+  // returned result is only built using ids in the `candidate_ids`. On success
+  // `set` is updated with context IDs based on `options` and `next_page_token`
+  // is updated with information for the caller to use for next page of results.
   virtual tensorflow::Status ListContextIDsUsingOptions(
-      const ListOperationOptions& options, RecordSet* record_set) = 0;
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set) = 0;
 
 };
 

--- a/ml_metadata/metadata_store/rdbms_metadata_access_object.h
+++ b/ml_metadata/metadata_store/rdbms_metadata_access_object.h
@@ -190,6 +190,10 @@ class RDBMSMetadataAccessObject : public MetadataAccessObject {
   tensorflow::Status FindExecutionsByContext(
       int64 context_id, std::vector<Execution>* executions) final;
 
+  tensorflow::Status FindExecutionsByContext(
+      int64 context_id, absl::optional<ListOperationOptions> list_options,
+      std::vector<Execution>* executions, std::string* next_page_token) final;
+
   tensorflow::Status CreateAttribution(const Attribution& attribution,
                                        int64* attribution_id) final;
 
@@ -199,6 +203,22 @@ class RDBMSMetadataAccessObject : public MetadataAccessObject {
   tensorflow::Status FindArtifactsByContext(
       int64 context_id, std::vector<Artifact>* artifacts) final;
 
+<<<<<<< HEAD
+=======
+  tensorflow::Status FindArtifactsByContext(
+      int64 context_id, absl::optional<ListOperationOptions> list_options,
+      std::vector<Artifact>* artifacts, std::string* next_page_token) final;
+
+  tensorflow::Status CreateParentContext(
+      const ParentContext& parent_context) final;
+
+  tensorflow::Status FindParentContextsByContextId(
+      int64 context_id, std::vector<Context>* contexts) final;
+
+  tensorflow::Status FindChildContextsByContextId(
+      int64 context_id, std::vector<Context>* contexts) final;
+
+>>>>>>> 15ed9f7 (Update GetExecutionsByContext and GetArtifactsByContext to support pagination and ordering results by ID, create time and last update time fields.)
   tensorflow::Status GetSchemaVersion(int64* db_version) final {
     return executor_->GetSchemaVersion(db_version);
   }
@@ -399,16 +419,24 @@ class RDBMSMetadataAccessObject : public MetadataAccessObject {
   tensorflow::Status FindEventsFromRecordSet(const RecordSet& event_record_set,
                                              std::vector<Event>* events);
 
-  // Retrieves the ids of the nodes based on 'options'. The returned record_set
+  // Retrieves the ids of the nodes based on 'options' and `candidate_ids`.
+  // If `candidate_ids` is non-empty, then only the nodes with those ids are
+  // considered when applying list options; when empty, all stored nodes are
+  // considered as candidates.
+  // The returned record_set
   // has a single row per id, with the corresponding value.
   template <typename Node>
   tensorflow::Status ListNodeIds(
-      const ListOperationOptions& options, RecordSet* record_set,
+      const ListOperationOptions& options,
+      const absl::Span<const int64> candidate_ids, RecordSet* record_set,
       Node* tag = nullptr /* used only for template instantiation*/);
 
   // Queries nodes stored in the metadata source using `options`.
   // `options` is the ListOperationOptions proto message defined
   // in metadata_store.
+  // If `candidate_ids` is non-empty, then only the nodes with those ids are
+  // considered when applying list options; when empty, all stored nodes are
+  // considered as candidates.
   // If successfull:
   // 1. `nodes` is updated with result set of size determined by
   //    max_result_size set in `options`.
@@ -421,6 +449,7 @@ class RDBMSMetadataAccessObject : public MetadataAccessObject {
   // 3. next_page_token cannot be decoded.
   template <typename Node>
   tensorflow::Status ListNodes(const ListOperationOptions& options,
+                               const absl::Span<const int64> candidate_ids,
                                std::vector<Node>* nodes,
                                std::string* next_page_token);
 

--- a/ml_metadata/proto/metadata_store_service.proto
+++ b/ml_metadata/proto/metadata_store_service.proto
@@ -553,18 +553,38 @@ message GetChildrenContextsByContextResponse {
 
 message GetArtifactsByContextRequest {
   optional int64 context_id = 1;
+
+  // Specify List options.
+  // Currently supports:
+  //   1. Field to order the results.
+  //   2. Page size.
+  optional ListOperationOptions options = 2;
 }
 
 message GetArtifactsByContextResponse {
   repeated Artifact artifacts = 1;
+
+  // Token to use to retreive next page of results if list options are used in
+  // the request.
+  optional string next_page_token = 2;
 }
 
 message GetExecutionsByContextRequest {
   optional int64 context_id = 1;
+
+  // Specify List options.
+  // Currently supports:
+  //   1. Field to order the results.
+  //   2. Page size.
+  optional ListOperationOptions options = 2;
 }
 
 message GetExecutionsByContextResponse {
   repeated Execution executions = 1;
+
+  // Token to use to retreive next page of results if list options are used in
+  // the request.
+  optional string next_page_token = 2;
 }
 
 


### PR DESCRIPTION
Update GetExecutionsByContext and GetArtifactsByContext to support pagination and ordering results by ID, create time and last update time fields.

The change further use the exposed options to in get_executions_by_context / get_artifacts_by_context python APIs to address feature request in #74.

PiperOrigin-RevId: 344194942