### PR TITLE
Update invalid link of MLMD tutorial in g3doc

### DIFF
--- a/g3doc/get_started.md
+++ b/g3doc/get_started.md
@@ -144,8 +144,9 @@ following list provides a non-exhaustive overview of some of the major benefits.
     changelist used for a workflow run; group the lineage by experiments; manage
     artifacts by projects.
 
-See the MLMD tutorial below for an example that shows you how to use the MLMD
-API and the metadata store to retrieve lineage information.
+See the [MLMD tutorial](https://www.tensorflow.org/tfx/tutorials/mlmd/mlmd_tutorial)
+for an example that shows you how to use the MLMD API and the metadata store to
+retrieve lineage information.
 
 ### Integrate ML Metadata into your ML Workflows
 

--- a/g3doc/get_started.md
+++ b/g3doc/get_started.md
@@ -144,9 +144,8 @@ following list provides a non-exhaustive overview of some of the major benefits.
     changelist used for a workflow run; group the lineage by experiments; manage
     artifacts by projects.
 
-See the [MLMD tutorial](../tutorials/mlmd/mlmd_tutorial) for an example that
-shows you how to use the MLMD API and the metadata store to retrieve lineage
-information.
+See the MLMD tutorial below for an example that shows you how to use the MLMD
+API and the metadata store to retrieve lineage information.
 
 ### Integrate ML Metadata into your ML Workflows
 


### PR DESCRIPTION
Fixes https://github.com/google/ml-metadata/issues/104

The MLMD tutorial link is invalid. Either removing the link because the remaining content of the same file shows as an example, or changing it to link to a new location.