### PR TITLE
Update Zlib to 1.2.12

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,9 +109,9 @@ protobuf_deps()
 http_archive(
     name = "zlib",
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    strip_prefix = "zlib-1.2.11",
-    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+    sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+    strip_prefix = "zlib-1.2.12",
+    urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
 )
 
 # pybind11


### PR DESCRIPTION
Per Zlib
```
Version 1.2.12 has these key improvements over 1.2.11:

Fix a deflate bug when using the Z_FIXED strategy that can result in out-of-bound accesses.
Fix a deflate bug when the window is full in deflate_stored().
Speed up CRC-32 computations by a factor of 1.5 to 3.
Use the hardware CRC-32 instruction on ARMv8 processors.
Speed up crc32_combine() with powers of x tables.
Add crc32_combine_gen() and crc32_combine_op() for fast combines.

Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.
```

Related to https://github.com/google/ml-metadata/issues/147