### PR TITLE
Python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Ignore all bazel-* symlinks. There is no full list since this can change
+# based on the name of the directory bazel is cloned into.
+/bazel-*
+
+build/
+dist/
+metadata_store_extension.so
+
+# egg
+*.egg-info/
+
+
+# generated grpc/protobuf files
+*_pb2.py
+*_pb2_grpc.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # ML Metadata
 
-[![Python](https://img.shields.io/badge/python%20-3.7%7C3.8-blue)](https://github.com/google/ml-metadata)
+[![Python](https://img.shields.io/badge/python%20-3.7%7C3.8%7C3.9-blue)](https://github.com/google/ml-metadata)
 [![PyPI](https://badge.fury.io/py/ml-metadata.svg)](https://badge.fury.io/py/ml-metadata)
 
 *ML Metadata (MLMD)* is a library for recording and retrieving metadata
@@ -53,11 +53,11 @@ Then, run the following at the project root:
 
 ```bash
 DOCKER_SERVICE=manylinux-python${PY_VERSION}
-sudo docker-compose build ${DOCKER_SERVICE}
-sudo docker-compose run ${DOCKER_SERVICE}
+sudo docker compose build ${DOCKER_SERVICE}
+sudo docker compose run ${DOCKER_SERVICE}
 ```
 
-where `PY_VERSION` is one of `{37, 38}`.
+where `PY_VERSION` is one of `{37, 38, 39}`.
 
 A wheel will be produced under `dist/`, and installed as follows:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,10 +2,11 @@
 
 ## Major Features and Improvements
 
+*   Adds python 3.9 support.
 ## Bug Fixes and Other Changes
 
 *   Updates Zlib to 1.2.12.
-
+*   Adds .gitignore support
 ## Breaking Changes
 
 ## Deprecations

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,8 +118,8 @@ http_archive(
 http_archive(
     name = "pybind11",
     build_file = "@pybind11_bazel//:pybind11.BUILD",
-    strip_prefix = "pybind11-2.4.3",
-    urls = ["https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz"],
+    strip_prefix = "pybind11-2.6.0",
+    urls = ["https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz"],
 )
 
 # Bazel rules for pybind11

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',


### PR DESCRIPTION
- Per #139  the next ml-metadata release will have python 3.9 support.
- Added .gitignore support
   - ignore files created via running `python setup.py bdist_wheel`
   - ignore files and folders created via running `docker compose run ${DOCKER_SERVICE}`
