### PR TITLE
Upgrade to ubuntu20.04 for grpc image

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile
+++ b/ml_metadata/tools/docker_server/Dockerfile
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(b/195701120) Introduces l.gcr.io/google/bazel:3.7.2 when it is available
-# and makes sure that it uses ubuntu 18.04 as base image. Currently the lastest
-# version only supports bazel 3.5.0.
-FROM ubuntu:18.04 as builder
+FROM ubuntu:20.04 as builder
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get update -y --option Acquire::Retries=3 && \
@@ -58,7 +57,7 @@ RUN bazel build -c opt --action_env=PATH \
 RUN mkdir -p /mlmd-src/third_party
 RUN cp -RL /mlmd-src/bazel-mlmd-src/external/libmysqlclient /mlmd-src/third_party/mariadb-connector-c
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY --from=builder /mlmd-src/bazel-bin/ml_metadata/metadata_store/metadata_store_server /bin/metadata_store_server
 COPY --from=builder /mlmd-src/third_party /mlmd-src/third_party


### PR DESCRIPTION
[Tensorflow images](github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/dockerfiles/dockerfiles.) use ubuntu20.04 

Also removed TODO comment since it doesn't look like there has been a bazel image published since version 3.5.0/september 2020 looking at https://console.cloud.google.com/gcr/images/cloud-marketplace-containers/GLOBAL/google/bazel

This also removes several security vulnerabilities associated wuth Ubuntu18.04.

```shell
grype gcr.io/tfx-oss-public/ml_metadata_store_server:1.7.0 --scope all-layers
NAME          INSTALLED               FIXED-IN          VULNERABILITY     SEVERITY
bash          4.4.18-2ubuntu1.2                         CVE-2019-18276    Low
coreutils     8.28-1ubuntu1                             CVE-2016-2781     Low
gcc-8-base    8.4.0-1ubuntu1~18.04                      CVE-2020-13844    Medium
gpgv          2.2.4-1ubuntu1.4                          CVE-2019-13050    Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2022-23218    Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2021-35942    Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2020-29562    Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2021-3999     Medium
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2022-23219    Low
libc-bin      2.27-3ubuntu1.4                           CVE-2015-8985     Negligible
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2019-25013    Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2020-27618    Low
libc-bin      2.27-3ubuntu1.4                           CVE-2016-10739    Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2016-10228    Negligible
libc-bin      2.27-3ubuntu1.4                           CVE-2009-5155     Negligible
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2021-3326     Low
libc-bin      2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2020-6096     Low
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2020-27618    Low
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2021-3326     Low
libc6         2.27-3ubuntu1.4                           CVE-2009-5155     Negligible
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2019-25013    Low
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2021-35942    Low
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2021-3999     Medium
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2022-23219    Low
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2022-23218    Low
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2016-10228    Negligible
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2020-29562    Low
libc6         2.27-3ubuntu1.4                           CVE-2015-8985     Negligible
libc6         2.27-3ubuntu1.4         2.27-3ubuntu1.5   CVE-2020-6096     Low
libc6         2.27-3ubuntu1.4                           CVE-2016-10739    Low
libgcc1       1:8.4.0-1ubuntu1~18.04                    CVE-2020-13844    Medium
libgnutls30   3.5.18-1ubuntu1.5                         CVE-2018-16868    Low
libncurses5   6.1-1ubuntu1.18.04                        CVE-2019-17594    Negligible
libncurses5   6.1-1ubuntu1.18.04                        CVE-2019-17595    Negligible
libncursesw5  6.1-1ubuntu1.18.04                        CVE-2019-17595    Negligible
libncursesw5  6.1-1ubuntu1.18.04                        CVE-2019-17594    Negligible
libpcre3      2:8.39-9                                  CVE-2017-11164    Negligible
libpcre3      2:8.39-9                                  CVE-2020-14155    Negligible
libpcre3      2:8.39-9                                  CVE-2019-20838    Low
libsepol1     2.7-1                                     CVE-2021-36085    Low
libsepol1     2.7-1                                     CVE-2021-36087    Low
libsepol1     2.7-1                                     CVE-2021-36086    Low
libsepol1     2.7-1                                     CVE-2021-36084    Low
libstdc++6    8.4.0-1ubuntu1~18.04                      CVE-2020-13844    Medium
libtasn1-6    4.13-2                                    CVE-2018-1000654  Negligible
libtinfo5     6.1-1ubuntu1.18.04                        CVE-2019-17595    Negligible
libtinfo5     6.1-1ubuntu1.18.04                        CVE-2019-17594    Negligible
login         1:4.5-1ubuntu2.2                          CVE-2013-4235     Low
ncurses-base  6.1-1ubuntu1.18.04                        CVE-2019-17594    Negligible
ncurses-base  6.1-1ubuntu1.18.04                        CVE-2019-17595    Negligible
ncurses-bin   6.1-1ubuntu1.18.04                        CVE-2019-17595    Negligible
ncurses-bin   6.1-1ubuntu1.18.04                        CVE-2019-17594    Negligible
passwd        1:4.5-1ubuntu2.2                          CVE-2013-4235     Low
perl-base     5.26.1-6ubuntu0.5                         CVE-2020-16156    Medium
tar           1.29b-2ubuntu0.2        1.29b-2ubuntu0.3  CVE-2021-20193    Low
zlib1g        1:1.2.11.dfsg-0ubuntu2                    CVE-2018-25032    Medium
```

Ubuntu 20.04 image built locally
```shell
grype gcr.io/tfx-oss-public/ml_metadata_store_server:latest --scope all-layers. 

 NAME        INSTALLED                 FIXED-IN  VULNERABILITY     SEVERITY
bash        5.0-6ubuntu1.1                      CVE-2019-18276    Low
coreutils   8.30-3ubuntu2                       CVE-2016-2781     Low
libgmp10    2:6.2.0+dfsg-4                      CVE-2021-43618    Low
libpcre3    2:8.39-12build1                     CVE-2019-20838    Low
libpcre3    2:8.39-12build1                     CVE-2020-14155    Negligible
libpcre3    2:8.39-12build1                     CVE-2017-11164    Negligible
libsepol1   3.0-1                               CVE-2021-36085    Low
libsepol1   3.0-1                               CVE-2021-36084    Low
libsepol1   3.0-1                               CVE-2021-36087    Low
libsepol1   3.0-1                               CVE-2021-36086    Low
libtasn1-6  4.16.0-2                            CVE-2018-1000654  Negligible
login       1:4.8.1-1ubuntu5.20.04.1            CVE-2013-4235     Low
passwd      1:4.8.1-1ubuntu5.20.04.1            CVE-2013-4235     Low
perl-base   5.30.0-9ubuntu0.2                   CVE-2020-16156    Medium
zlib1g      1:1.2.11.dfsg-2ubuntu1.2            CVE-2018-25032    Medium