### PR TITLE
Update g3doc for PostgreSQL

### DIFF
--- a/g3doc/get_started.md
+++ b/g3doc/get_started.md
@@ -98,6 +98,32 @@ connection_config.mysql.ssl_options.verify_server_cert = '...'
 store = metadata_store.MetadataStore(connection_config)
 ```
 
+*   **PostgreSQL** connects to a PostgreSQL server.
+
+```python
+connection_config = metadata_store_pb2.ConnectionConfig()
+connection_config.postgresql.host = '...'
+connection_config.postgresql.port = '...'
+connection_config.postgresql.user = '...'
+connection_config.postgresql.password = '...'
+connection_config.postgresql.dbname = '...'
+store = metadata_store.MetadataStore(connection_config)
+```
+
+Similarly, when using a PostgreSQL instance with Google CloudSQL
+([quickstart](https://cloud.google.com/sql/docs/postgres/quickstart),
+[connect-overview](https://cloud.google.com/sql/docs/postgres/connect-overview)),
+one could also use SSL option if applicable.
+
+```python
+connection_config.postgresql.ssloption.sslmode = '...' # disable, allow, verify-ca, verify-full, etc.
+connection_config.postgresql.ssloption.sslcert = '...'
+connection_config.postgresql.ssloption.sslkey = '...'
+connection_config.postgresql.ssloption.sslpassword = '...'
+connection_config.postgresql.ssloption.sslrootcert = '...'
+store = metadata_store.MetadataStore(connection_config)
+```
+
 ## Data model
 
 The Metadata Store uses the following data model to record and retrieve metadata


### PR DESCRIPTION

Hi! 👋 

I've been following [Kubeflow Summit 2023](https://www.kubeflow.org/events/kubeflow-summit-2023/), where in a presentation it was mentioned the integration of MLMD with PostgreSQL is done.

Then, I noticed release notes confirmed 1.14.0 introduced support for PostgreSQL ([here](https://github.com/google/ml-metadata/releases/tag/v1.14.0#:~:text=Support%20PostgreSQL%20database%20type), also [here](https://github.com/google/ml-metadata/blob/de25304b6d123e3044b64be9ceaf979f61483fe5/RELEASE.md?plain=1#L16-L20C24)) confirming what I've learned in the talk! 🚀 💪 
Thank you so much for this awesome new feature!

I've noticed however the documentation did not list an example for PostgreSQL ([here](https://www.tensorflow.org/tfx/guide/mlmd#metadata_storage_backends_and_store_connection_configuration))
so I'm proposing with this PR to add an example for it, as done analogously for SQLite and MySQL.

I hope this helps!

p.s.: I'm also participating in [Hacktoberfest](https://hacktoberfest.com/participation/#faq:~:text=YOUR%20PR/MRS%20MUST%20BE%20MERGED%2C%20HAVE%20THE%20%E2%80%9CHACKTOBERFEST%2DACCEPTED%E2%80%9D%20LABEL), so in case you could add label `hacktoberfest-accepted` in github if you think this PR is helpful, it would be appreciated, but no problem if it cannot be done and thank you in any case