### PR TITLE
Update g3doc for remote gRPC usage

### DIFF
--- a/g3doc/get_started.md
+++ b/g3doc/get_started.md
@@ -390,7 +390,37 @@ connection_config {
 }
 ```
 
-*   Create the client stub and use it in Python
+*   Create the `MetadataStore` providing a `MetadataStoreClientConfig` object
+
+```python
+import ml_metadata as mlmd
+from ml_metadata.metadata_store import metadata_store
+from ml_metadata.proto import metadata_store_pb2
+
+# Setup store client config
+client_connection_config = metadata_store_pb2.MetadataStoreClientConfig()
+client_connection_config.host = 'localhost'
+client_connection_config.port = 8080
+
+store = metadata_store.MetadataStore(client_connection_config)
+```
+
+*   Use MLMD store following the same instructions provided in [Integrate ML Metadata into your ML Workflows](#integrate-ml-metadata-into-your-ml-workflows) section.
+
+```python
+# Create ArtifactType, e.g., DataSet
+data_type = metadata_store_pb2.ArtifactType()
+data_type.name = "DataSet"
+data_type.properties["day"] = metadata_store_pb2.INT
+data_type.properties["split"] = metadata_store_pb2.STRING
+data_type_id = store.put_artifact_type(data_type)
+
+...
+```
+
+Alternatively, to have complete control over gRPC requests and responses:
+
+*   Create the `MetadataStoreServiceStub` by supplying a gRPC connection and use it in Python
 
 ```python
 from grpc import insecure_channel
@@ -402,7 +432,7 @@ channel = insecure_channel('localhost:8080')
 stub = metadata_store_service_pb2_grpc.MetadataStoreServiceStub(channel)
 ```
 
-*   Use MLMD with RPC calls
+*   Use MLMD stub with RPC calls
 
 ```python
 # Create ArtifactTypes, e.g., Data and Model


### PR DESCRIPTION
Hello team,

In recent times, we had the opportunity to experiment with the usage of ml-metadata following the [official documentation](https://www.tensorflow.org/tfx/guide/mlmd). Specifically, we focused on using _MLMD with a gRPC server_ [1]. Initially, we found it not very clear why, in the case of a gRPC server, users are _forced_ to handle RPC requests/responses, thus requiring a different approach compared to what is shown in the _non-gRPC server scenario_ [2].

After some code investigation, we discovered that it is actually possible to use the `MetadataStore` by providing it with a `MetadataStoreClientConfig` as a parameter (with proper MLMD gRPC host and port). 
This way, users do not need to manage gRPC requests and responses themselves, if they do have have a valid reason to do so.

```python
client_connection_config = metadata_store_pb2.MetadataStoreClientConfig()
client_connection_config.host = 'localhost'
client_connection_config.port = 8080

store = metadata_store.MetadataStore(client_connection_config)
```

In order to demonstrate its usage, I have created a simple notebook [3] that precisely executes all the steps described in the documentation [2] by making use of a `MetadataStore` configured with a `MetadataStoreClientConfig`.

We believe that adding this information to the documentation could be very useful and helpful for all ml-metadata users.

Hope this helps!

[1] https://www.tensorflow.org/tfx/guide/mlmd#use_mlmd_with_a_remote_grpc_server
[2] https://www.tensorflow.org/tfx/guide/mlmd#integrate_ml_metadata_into_your_ml_workflows
[3] https://github.com/lampajr/demo20231018-mlmd-showcase/blob/main/mlmd-grpc-store.ipynb