### PR TITLE
fix postgresql string property index

### DIFF
--- a/ml_metadata/util/metadata_source_query_config.cc
+++ b/ml_metadata/util/metadata_source_query_config.cc
@@ -5555,6 +5555,9 @@ R"pb(
 R"pb(
   # secondary indices in the current schema.
   secondary_indices {
+    query: " CREATE EXTENSION IF NOT EXISTS pg_trgm; "
+  }
+  secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS idx_artifact_uri ON Artifact (uri); "
            " CREATE INDEX IF NOT EXISTS "
            "  idx_artifact_create_time_since_epoch "
@@ -5610,7 +5613,7 @@ R"pb(
   secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS "
            "  idx_artifact_property_string "
-           "  ON ArtifactProperty (name, is_custom_property, string_value); "
+           "  ON ArtifactProperty USING gist (name gist_trgm_ops, string_value gist_trgm_ops); "
   }
   secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS "
@@ -5625,7 +5628,7 @@ R"pb(
   secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS "
            "  idx_execution_property_string "
-           "  ON ExecutionProperty (name, is_custom_property, string_value); "
+           "  ON ExecutionProperty USING gist (name gist_trgm_ops, string_value gist_trgm_ops); "
   }
   secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS "
@@ -5640,7 +5643,7 @@ R"pb(
   secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS "
            "  idx_context_property_string "
-           "  ON ContextProperty (name, is_custom_property, string_value); "
+           "  ON ContextProperty USING gist (name gist_trgm_ops, string_value gist_trgm_ops); "
   }
   secondary_indices {
     query: " CREATE INDEX IF NOT EXISTS idx_type_external_id "


### PR DESCRIPTION
See #194 

### Proposed solution(s)

Taking MLMD's Context string property as example,

S1. modify PostgreSQL index to be ~like:
```
CREATE INDEX idx_context_property_string_gist ON public.contextproperty USING gist (name gist_trgm_ops, string_value gist_trgm_ops);
```
or derivatives. (requires first `CREATE EXTENSION pg_trgm;`)

S2. modify PostgreSQL index to be ~like:
```
CREATE INDEX idx_context_property_string ON public.contextproperty USING btree (name, is_custom_property, "substring"(string_value, 1, 255));
```
making it similar to MySQL behaviour, less ideal because would only be partially helpful on queries longer term.

(S3. a third solution _would_ be to drop the `idx_..._property_string` indexes altogether which seems to be causing the issue, but I don't think is worth considering).

### This PR
The scope of this PR is to demonstrate S1 in practice,
or discuss alternative approaches.

/cc @XinranTang could you kindly consult with the team and feedback on this, please?