### PR TITLE
Fix missing order by fields in `SELECT` statement

### DIFF
--- a/ml_metadata/metadata_store/postgresql_query_executor.cc
+++ b/ml_metadata/metadata_store/postgresql_query_executor.cc
@@ -903,7 +903,7 @@ absl::Status PostgreSQLQueryExecutor::ListNodeIDsUsingOptions(
                        sql_gen_status.message()));
     }
     sql_query = absl::Substitute(
-        "SELECT distinct $0.id, $0.create_time_since_epoch FROM $1 WHERE $2 "
+        "SELECT distinct $0.id, $0.create_time_since_epoch, $0.last_update_time_since_epoch FROM $1 WHERE $2 "
         "AND ",
         *node_table_alias,
         // TODO(b/257334039): remove query_version-conditional logic

--- a/ml_metadata/metadata_store/query_config_executor.cc
+++ b/ml_metadata/metadata_store/query_config_executor.cc
@@ -844,7 +844,7 @@ absl::Status QueryConfigExecutor::ListNodeIDsUsingOptions(
                        sql_gen_status.message()));
     }
     sql_query = absl::Substitute(
-        "SELECT distinct $0.`id` FROM $1 WHERE $2 AND ", *node_table_alias,
+        "SELECT distinct $0.`id`, $0.`create_time_since_epoch`, $0.`last_update_time_since_epoch` FROM $1 WHERE $2 AND ", *node_table_alias,
         // TODO(b/257334039): remove query_version-conditional logic
         query_builder.GetFromClause(query_version),
         query_builder.GetWhereClause());


### PR DESCRIPTION
Currently, it's not possible to order by creation time or update time when using a MySQL backend. The PostgresQL backend also won't allow ordering by update time.

All such queries fail with (e.g. on MySQL):
```raw
rpc error: code = Internal desc = mysql_query failed: errno: Expression #1 of ORDER BY clause is not in SELECT list, references column 'model_registry.table_0.create_time_since_epoch' which is not in SELECT list; this is incompatible with DISTINCT, error: Expression #1 of ORDER BY clause is not in SELECT list, references column 'model_registry.table_0.create_time_since_epoch' which is not in SELECT list; this is incompatible with DISTINCT
```

## Description
Fixes missing order by fields in `SELECT` statement.

Fixes: kubeflow/model-registry#358

## How Has This Been Tested?

See kubeflow/model-registry#358.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
