### PR TITLE
[ppc64le] Added GCC-11 and Power support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,7 @@ http_archive(
     build_file = "//ml_metadata:postgresql.BUILD",
     workspace_file_content = "//ml_metadata:postgresql.WORKSPACE",
     sha256 = "9868c1149a04bae1131533c5cbd1c46f9c077f834f6147abaef8791a7c91b1a1",
+    patches = ["//ml_metadata/third_party:postgresql.patch",],
     strip_prefix = "postgresql-12.1",
     urls = [
         "https://ftp.postgresql.org/pub/source/v12.1/postgresql-12.1.tar.gz",
@@ -50,10 +51,10 @@ http_archive(
 
 http_archive(
     name = "boringssl",
-    sha256 = "1188e29000013ed6517168600fc35a010d58c5d321846d6a6dfee74e4c788b45",
-    strip_prefix = "boringssl-7f634429a04abc48e2eb041c81c5235816c96514",
+    sha256 = "579cb415458e9f3642da0a39a72f79fdfe6dc9c1713b3a823f1e276681b9703e",
+    strip_prefix = "boringssl-648cbaf033401b7fe7acdce02f275b06a88aab5c",
     urls = [
-        "https://github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz",
+        "https://github.com/google/boringssl/archive/648cbaf033401b7fe7acdce02f275b06a88aab5c.tar.gz",
     ],
 )
 
@@ -252,7 +253,7 @@ http_archive(
     name = "com_google_zetasql",
     urls = ["https://github.com/google/zetasql/archive/%s.zip" % ZETASQL_COMMIT],
     strip_prefix = "zetasql-%s" % ZETASQL_COMMIT,
-    #patches = ["//ml_metadata/third_party:zetasql.patch"],
+    patches = ["//ml_metadata/third_party:zetasql.patch"],
     sha256 = '651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840'
 )
 

--- a/ml_metadata/third_party/postgresql.patch
+++ b/ml_metadata/third_party/postgresql.patch
@@ -1,0 +1,37 @@
+diff --git src/port/pg_bitutils.c src/port/pg_bitutils.c
+index 7847e8a..17714af 100644
+--- src/port/pg_bitutils.c
++++ src/port/pg_bitutils.c
+@@ -12,12 +12,14 @@
+  */
+ #include "c.h"
+
++#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__)
+ #ifdef HAVE__GET_CPUID
+ #include <cpuid.h>
+ #endif
+ #ifdef HAVE__CPUID
+ #include <intrin.h>
+ #endif
++#endif
+
+ #include "port/pg_bitutils.h"
+
+@@ -141,6 +143,7 @@ int			(*pg_popcount64) (uint64 word) = pg_popcount64_slow;
+ static bool
+ pg_popcount_available(void)
+ {
++#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__)
+ 	unsigned int exx[4] = {0, 0, 0, 0};
+
+ #if defined(HAVE__GET_CPUID)
+@@ -152,6 +155,9 @@ pg_popcount_available(void)
+ #endif
+
+ 	return (exx[2] & (1 << 23)) != 0;	/* POPCNT */
++#else
++	return false;
++#endif
+ }
+
+ /*

--- a/ml_metadata/third_party/zetasql.patch
+++ b/ml_metadata/third_party/zetasql.patch
@@ -1,0 +1,102 @@
+diff --git bazel/m4.patch bazel/m4.patch
+index 544cbaa..c536bdc 100644
+--- bazel/m4.patch
++++ bazel/m4.patch
+@@ -131,3 +131,97 @@
+  # else
+  #  define USE_SNPRINTF 0
+  # endif
++diff --git lib/c-stack.c lib/c-stack.c
++index 5353c08..a608fbe 100644
++--- lib/c-stack.c
+++++ lib/c-stack.c
++@@ -50,16 +50,16 @@
++ #if ! HAVE_STACK_T && ! defined stack_t
++ typedef struct sigaltstack stack_t;
++ #endif
++-#ifndef SIGSTKSZ
++-# define SIGSTKSZ 16384
++-#elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
++-/* libsigsegv 2.6 through 2.8 have a bug where some architectures use
++-   more than the Linux default of an 8k alternate stack when deciding
++-   if a fault was caused by stack overflow.  */
++-# undef SIGSTKSZ
++-# define SIGSTKSZ 16384
++-#endif
++-
+++/* Storage for the alternate signal stack.
+++ * 64 KiB is not too large for Gnulib-using apps, and is large enough
+++ * for all known platforms. Smaller sizes may run into trouble.
+++ * For example, libsigsegv 2.6 through 2.8 have a bug where some
+++ * architectures use more than the Linux default of an 8 KiB alternate
+++ * stack when deciding if a fault was caused by stack overflow. */
+++static max_align_t alternate_signal_stack[(64 * 1024
+++                                      + sizeof (max_align_t) - 1)
+++                                      / sizeof (max_align_t)];
+++
++ #include <stdlib.h>
++ #include <string.h>
++
++@@ -128,18 +128,6 @@ die (int signo)
++ #if (HAVE_SIGALTSTACK && HAVE_DECL_SIGALTSTACK \
++      && HAVE_STACK_OVERFLOW_HANDLING) || HAVE_LIBSIGSEGV
++
++-/* Storage for the alternate signal stack.  */
++-static union
++-{
++-  char buffer[SIGSTKSZ];
++-
++-  /* These other members are for proper alignment.  There's no
++-     standard way to guarantee stack alignment, but this seems enough
++-     in practice.  */
++-  long double ld;
++-  long l;
++-  void *p;
++-} alternate_signal_stack;
++
++ static void
++ null_action (int signo __attribute__ ((unused)))
++@@ -205,8 +193,8 @@ c_stack_action (void (*action) (int))
++
++   /* Always install the overflow handler.  */
++   if (stackoverflow_install_handler (overflow_handler,
++-                                     alternate_signal_stack.buffer,
++-                                     sizeof alternate_signal_stack.buffer))
+++                                     alternate_signal_stack,
+++                                     sizeof alternate_signal_stack))
++     {
++       errno = ENOTSUP;
++       return -1;
++@@ -279,14 +267,14 @@ c_stack_action (void (*action) (int))
++   stack_t st;
++   struct sigaction act;
++   st.ss_flags = 0;
+++  st.ss_sp = alternate_signal_stack;
+++  st.ss_size = sizeof alternate_signal_stack;
++ # if SIGALTSTACK_SS_REVERSED
++   /* Irix mistakenly treats ss_sp as the upper bound, rather than
++      lower bound, of the alternate stack.  */
++-  st.ss_sp = alternate_signal_stack.buffer + SIGSTKSZ - sizeof (void *);
++-  st.ss_size = sizeof alternate_signal_stack.buffer - sizeof (void *);
++-# else
++-  st.ss_sp = alternate_signal_stack.buffer;
++-  st.ss_size = sizeof alternate_signal_stack.buffer;
+++  st.ss_size -= sizeof (void *);
+++  char *ss_sp = st.ss_sp;
+++  st.ss_sp = ss_sp + st.ss_size;
++ # endif
++   r = sigaltstack (&st, NULL);
++   if (r != 0)
++diff --git lib/c-stack.h lib/c-stack.h
++index efd3b8f..df8a790 100644
++--- lib/c-stack.h
+++++ lib/c-stack.h
++@@ -34,7 +34,7 @@
++    A null ACTION acts like an action that does nothing.
++
++    ACTION must be async-signal-safe.  ACTION together with its callees
++-   must not require more than SIGSTKSZ bytes of stack space.  Also,
+++   must not require more than 64 KiB of stack space.  Also,
++    ACTION should not call longjmp, because this implementation does
++    not guarantee that it is safe to return to the original stack.
++


### PR DESCRIPTION
This pull request addresses build issues encountered on Power architecture with GCC-11, specifically related to the following components: pg_bitutils.c (PostgreSQL), m4, and BoringSSL. The fixes ensure better compatibility and successful compilation on Power systems using GCC-11.

**Summary of Changes**
**1. Power Architecture Support** **– PostgreSQL Patch**

A patch has been added to resolve a build error in pg_bitutils.c encountered specifically on Power architecture.
**Patch location**: //ml_metadata/third_party:postgresql.patch

**2. GCC-11 Compatibility Fix** **– m4 Patch**
Resolved the following compilation error in c-stack.c when building m4 with GCC-11:
error: 
`missing binary operator before token "("
#elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384`


**Upstream patch taken from Debian sources:**
https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/m4/1.4.18-5ubuntu1/m4_1.4.18-5ubuntu1.debian.tar.xz
**Patch location:** ml_metadata/third_party:zetasql.patch

**3. Boringssl Update for GCC-11**
A build error was encountered with the previous version of BoringSSL on Power architecture using GCC-11.
The issue was resolved by upgrading the boringssl version.
**Update location**: WORKSPACE file


**Purpose of this PR:**
These changes are necessary to ensure successful builds of ml_metadata on Power architecture with GCC-11. They improve cross-platform compatibility and ensure smoother CI/CD integration for platforms using newer compilers.
 