### PR TITLE
fix: correct mkdocstrings import config for v2.0 compatibility

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,8 +68,8 @@ plugins:
               - "!_test$"
             extensions:
               - griffe_inherited_docstrings
-          import:
-            - https://docs.python.org/3/objects.inv
+      import:
+        - https://docs.python.org/3/objects.inv
   - caption:
       figure:
         ignore_alt: true


### PR DESCRIPTION
## Summary

This PR fixes the documentation build failure by correcting the `mkdocstrings` configuration in `mkdocs.yml`. The `import` key has been moved from the handler-specific options to the plugin root level, which is the correct location for mkdocstrings-python 2.0+.

## Problem

The documentation build was failing with the following error:

```
TypeError: PythonConfig.__init__() got an unexpected keyword argument 'import'
```

This error occurred because the `import` configuration was incorrectly nested under `handlers.python.import` instead of being at the root `mkdocstrings.import` level.

## Solution

Moved the `import` key from:

```yaml
handlers:
  python:
    options:
      ...
    import:  # Wrong location
      - https://docs.python.org/3/objects.inv
```

To:
```yaml
handlers:
  python:
    options:
      ...
import:  # Correct location
  - https://docs.python.org/3/objects.inv
```

## Testing

- [x] Documentation builds successfully with `mkdocs build`
- [x] GitHub Actions workflow passes (refer - https://github.com/czgdp1807/ml-metadata/pull/3)
- [x] Local preview with `mkdocs serve` works correctly
