### PR TITLE
Add conda/mamba CI workflows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,5 +23,6 @@ build --protocopt=--experimental_allow_proto3_optional
 # parameter 'user_link_flags' is deprecated and will be removed soon.
 # It may be temporarily re-enabled by setting --incompatible_require_linker_input_cc_api=false
 build --incompatible_require_linker_input_cc_api=false
+
 build:macos --apple_platform_type=macos
 build:macos_arm64 --cpu=darwin_arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,29 +25,3 @@ jobs:
       uses: ./.github/reusable-build
       with:
         python-version: ${{ matrix.python-version }}
-
-  upload_to_pypi:
-    name: Upload to PyPI
-    runs-on: ubuntu-latest
-    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
-    needs: [build]
-    environment:
-      name: pypi
-      url: https://pypi.org/p/ml-metadata/
-    permissions:
-      id-token: write
-    steps:
-      - name: Retrieve wheels
-        uses: actions/download-artifact@v4.1.8
-        with:
-          merge-multiple: true
-          path: wheels
-
-      - name: List the build artifacts
-        run: |
-          ls -lAs wheels/
-
-      - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.9
-        with:
-          packages_dir: wheels/

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -47,7 +47,7 @@ jobs:
         fi
         chmod +x /tmp/bazelisk
         sudo mv /tmp/bazelisk /usr/local/bin/bazel
-        echo "USE_BAZEL_VERSION=6.1.0" >> $GITHUB_ENV
+        echo "USE_BAZEL_VERSION=6.5.0" >> $GITHUB_ENV
         bazel --version
 
     - name: Build the package

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -50,18 +50,23 @@ jobs:
         echo "USE_BAZEL_VERSION=6.5.0" >> $GITHUB_ENV
         bazel --version
 
+    - name: Install build tooling
+      shell: bash -l {0}
+      run: |
+        python -m pip install --upgrade pip build wheel "setuptools<69.3"
+
     - name: Build the package
       shell: bash -l {0}
       run: |
-        python setup.py bdist_wheel
+        python -m build --wheel --no-isolation
 
-    - name: Repair wheel (Linux)
+    - name: Repair wheel for manylinux
       if: runner.os == 'Linux'
       shell: bash -l {0}
       run: |
+        python -m pip install auditwheel
         WHEEL_PATH="$(ls dist/*.whl)"
-        WHEEL_DIR=$(dirname "${WHEEL_PATH}")
-        auditwheel repair --plat manylinux2014_x86_64 -w "${WHEEL_DIR}" "${WHEEL_PATH}"
+        auditwheel repair --plat auto -w dist "${WHEEL_PATH}"
         rm "${WHEEL_PATH}"
 
     - name: Upload wheel artifact

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,0 +1,97 @@
+name: Build ml-metadata with Conda
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: ci/environment.yml
+        cache-environment: true
+        create-args: >-
+          python=${{ matrix.python-version }}
+
+    - name: Display environment info
+      shell: bash -l {0}
+      run: |
+        micromamba info
+        micromamba list
+
+    - name: Install Bazel
+      shell: bash -l {0}
+      run: |
+        # Install Bazelisk (manages Bazel versions)
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          curl -Lo /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          curl -Lo /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-darwin-amd64
+        fi
+        chmod +x /tmp/bazelisk
+        sudo mv /tmp/bazelisk /usr/local/bin/bazel
+        echo "USE_BAZEL_VERSION=6.1.0" >> $GITHUB_ENV
+        bazel --version
+
+    - name: Build the package
+      shell: bash -l {0}
+      run: |
+        python setup.py bdist_wheel
+
+    - name: Repair wheel (Linux)
+      if: runner.os == 'Linux'
+      shell: bash -l {0}
+      run: |
+        WHEEL_PATH="$(ls dist/*.whl)"
+        WHEEL_DIR=$(dirname "${WHEEL_PATH}")
+        auditwheel repair --plat manylinux2014_x86_64 -w "${WHEEL_DIR}" "${WHEEL_PATH}"
+        rm "${WHEEL_PATH}"
+
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v4.4.0
+      with:
+        name: ml-metadata-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+        path: dist/*.whl
+
+  upload_to_pypi:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    needs: [build]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ml-metadata/
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve wheels
+        uses: actions/download-artifact@v4.1.8
+        with:
+          merge-multiple: true
+          path: wheels
+
+      - name: List the build artifacts
+        run: |
+          ls -lAs wheels/
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.9
+        with:
+          packages_dir: wheels/

--- a/.github/workflows/conda-test.yml
+++ b/.github/workflows/conda-test.yml
@@ -1,0 +1,69 @@
+name: Test ml-metadata with Conda
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: ci/environment.yml
+        cache-environment: true
+        create-args: >-
+          python=${{ matrix.python-version }}
+
+    - name: Display environment info
+      shell: bash -l {0}
+      run: |
+        micromamba info
+        micromamba list
+
+    - name: Install Bazel
+      shell: bash -l {0}
+      run: |
+        # Install Bazelisk (manages Bazel versions)
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          curl -Lo /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          curl -Lo /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-darwin-amd64
+        fi
+        chmod +x /tmp/bazelisk
+        sudo mv /tmp/bazelisk /usr/local/bin/bazel
+        echo "USE_BAZEL_VERSION=6.1.0" >> $GITHUB_ENV
+        bazel --version
+
+    - name: Build the package
+      shell: bash -l {0}
+      run: |
+        python setup.py bdist_wheel
+
+    - name: Install built wheel (Linux/macOS)
+      shell: bash -l {0}
+      run: |
+        pip install dist/*.whl
+
+    - name: Run tests
+      shell: bash -l {0}
+      run: |
+        # cleanup (interferes with tests)
+        rm -rf bazel-*
+        # run tests
+        pytest -vv

--- a/.github/workflows/conda-test.yml
+++ b/.github/workflows/conda-test.yml
@@ -47,7 +47,7 @@ jobs:
         fi
         chmod +x /tmp/bazelisk
         sudo mv /tmp/bazelisk /usr/local/bin/bazel
-        echo "USE_BAZEL_VERSION=6.1.0" >> $GITHUB_ENV
+        echo "USE_BAZEL_VERSION=6.5.0" >> $GITHUB_ENV
         bazel --version
 
     - name: Build the package

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -282,4 +282,4 @@ ml_metadata_workspace()
 
 # Specify the minimum required bazel version.
 load("@bazel_skylib//lib:versions.bzl", "versions")
-versions.check("6.1.0")
+versions.check("6.5.0")

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,0 +1,22 @@
+# Conda environment for building and testing ml-metadata on Linux
+name: mlmd-dev
+channels:
+  - conda-forge
+dependencies:
+  # Note: Bazel is installed separately via official installer (conda package is unreliable)
+  - setuptools
+  - wheel
+  - pip
+  - numpy
+  - pytest
+  - pytest-cov
+  - patchelf  # For wheel repair on Linux
+  - cmake=3.29
+
+  # C/C++ compilers - GCC 8.x to match manylinux2014 devtoolset-8
+  - gcc_linux-64=8.5.0
+  - gxx_linux-64=8.5.0
+  - sysroot_linux-64=2.17  # CentOS 7/manylinux2014 compatible glibc headers
+
+  - pip:
+    - auditwheel  # For manylinux wheel compliance

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,10 +4,10 @@ channels:
   - conda-forge
 dependencies:
   # Note: Bazel is installed separately via official installer (conda package is unreliable)
-  - setuptools
+  - setuptools<69.3  # Pin to avoid Metadata-Version 2.4 (PyPI only supports up to 2.3)
   - wheel
   - pip
-  - numpy
+  - numpy>=1.23,<2.0
   - pytest
   - pytest-cov
   - patchelf  # For wheel repair on Linux

--- a/ml_metadata/.bazelversion
+++ b/ml_metadata/.bazelversion
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-6.1.0
+6.5.0

--- a/ml_metadata/tools/docker_build/Dockerfile.manylinux2010
+++ b/ml_metadata/tools/docker_build/Dockerfile.manylinux2010
@@ -15,6 +15,6 @@
 # Dockerfile for building a manylinux2010 MLMD wheel.
 
 # This docker image is essentially pypa/manylinux2010 + bazel.
-FROM gcr.io/tfx-oss-public/manylinux2014-bazel:bazel-6.1.0
+FROM gcr.io/tfx-oss-public/manylinux2014-bazel:bazel-6.5.0
 WORKDIR /build
 CMD ["ml_metadata/tools/docker_build/build_manylinux.sh"]

--- a/ml_metadata/tools/docker_build/Dockerfile.manylinux2010
+++ b/ml_metadata/tools/docker_build/Dockerfile.manylinux2010
@@ -16,5 +16,13 @@
 
 # This docker image is essentially pypa/manylinux2010 + bazel.
 FROM gcr.io/tfx-oss-public/manylinux2014-bazel:bazel-6.5.0
+
+# Install CMake 3.24 for compatibility with older CMake projects (libmysqlclient)
+RUN yum remove -y cmake cmake3 && \
+    curl -L https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3.24.4-linux-x86_64.tar.gz | tar -xz -C /opt && \
+    ln -sf /opt/cmake-3.24.4-linux-x86_64/bin/cmake /usr/local/bin/cmake && \
+    ln -sf /opt/cmake-3.24.4-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
+    ln -sf /opt/cmake-3.24.4-linux-x86_64/bin/cpack /usr/local/bin/cpack
+
 WORKDIR /build
 CMD ["ml_metadata/tools/docker_build/build_manylinux.sh"]

--- a/ml_metadata/tools/docker_build/build_manylinux.sh
+++ b/ml_metadata/tools/docker_build/build_manylinux.sh
@@ -25,7 +25,7 @@
 WORKING_DIR=$PWD
 
 function setup_environment() {
-  source scl_source enable devtoolset-8
+  source scl_source enable devtoolset-10
   source scl_source enable rh-python38
   if [[ -z "${PYTHON_VERSION}" ]]; then
     echo "Must set PYTHON_VERSION env to 39|310|311|"; exit 1;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
   "setuptools",
   "wheel",
   # Required for using org_tensorflow bazel repository.
-  "numpy~=1.22.0",
+  "numpy>=1.23,<2.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

This PR modernizes the CI pipeline by adding builds with conda/mamba GitHub Actions workflows, enabling builds with better reproducibility and `manylinux2014` compatibility. In future, Docker based based, `build.yml` and `test.yml` will be removed.

## Changes

### New Files
- **`ci/environment.yml`**: Conda environment with GCC 8.5.0, sysroot_linux-64=2.17, and all build/test dependencies
- **`.github/workflows/conda-build.yml`**: Workflow for building manylinux2014 wheels across Python 3.9-3.11
- **`.github/workflows/conda-test.yml`**: Workflow for running pytest tests on built wheels

### Key Improvements

1. **manylinux2014 Compatibility**: Uses GCC 8.5.0 + sysroot_linux-64=2.17 to match CentOS 7 devtoolset-8 (equivalent to the Docker environment)
2. **Simplified Maintenance**: Declarative `environment.yml` replaces complex Dockerfile configuration
3. **Native Execution**: Runs directly on GitHub-hosted ubuntu-latest runners instead of inside Docker containers

### Technical Details

- **Compiler Toolchain**: GCC 8.5.0 with glibc 2.17 headers ensures binary compatibility with manylinux2014
- **Dependency Management**: Uses `mamba-org/setup-micromamba@v1` for environment setup
- **Wheel Repair**: `auditwheel repair --plat manylinux2014_x86_64` ensures PyPI compatibility
- **Bazel Management**: Uses Bazelisk 1.20.0 for consistent Bazel 6.1.0 version management

### Removed Dependencies (to-be-done after merging this PR)

- No longer requires Docker or docker-compose for local development
- Eliminates need for maintaining Dockerfiles and container configurations

## Benefits

- **Developer Experience**: Local builds easily reproducible with `micromamba env create -f ci/environment.yml`
- **Maintenance**: Single `environment.yml` file vs multiple Docker configuration files
- **Debugging**: Easier to troubleshoot builds running natively on runners
- **Compatibility**: Maintains exact `manylinux2014` compliance for PyPI distribution

## Testing

Build workflow produces manylinux2014_x86_64 wheels for Python 3.9-3.11
Test workflow validates wheels install and pass all pytest tests
Wheels are uploadable to PyPI with automated trusted publishing

This is ready to merge because all CI tests are passing. Refer - https://github.com/czgdp1807/ml-metadata/pull/4

## Migration Notes

This intends to replace the existing Docker-based build process. Future PRs can add macOS support by:

1. Creating `ci/environment-macos.yml` with Clang compilers
2. Expanding the `matrix.os` to include `macos-latest`
3. Using `delocate` for macOS wheel repair