### PR TITLE
R1.17.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -282,4 +282,4 @@ ml_metadata_workspace()
 
 # Specify the minimum required bazel version.
 load("@bazel_skylib//lib:versions.bzl", "versions")
-versions.check("6.1.0")
+versions.check("6.5.0")

--- a/ml_metadata/.bazelversion
+++ b/ml_metadata/.bazelversion
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-6.1.0
+6.5.0

--- a/ml_metadata/libmysqlclient.BUILD
+++ b/ml_metadata/libmysqlclient.BUILD
@@ -26,7 +26,7 @@ genrule(
         "cd $$TMP_DIR",
         "mkdir build",
         "cd build",
-        "cmake .. -DCMAKE_BUILD_TYPE=Release $${CMAKE_ICONV_FLAG-}",
+        "cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/opt/rh/devtoolset-10/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-10/root/usr/bin/g++ -DCMAKE_POLICY_VERSION_MINIMUM=3.5 $${CMAKE_ICONV_FLAG-}",
         "cd ..",
         "cp -R ./build/* $$INSTALL_DIR",
         "rm -rf $$TMP_DIR",

--- a/ml_metadata/tools/docker_build/Dockerfile.manylinux2010
+++ b/ml_metadata/tools/docker_build/Dockerfile.manylinux2010
@@ -13,8 +13,24 @@
 # limitations under the License.
 
 # Dockerfile for building a manylinux2010 MLMD wheel.
+# We use manylinux2014 as it has a modern GCC.
+FROM quay.io/pypa/manylinux2014_x86_64
 
-# This docker image is essentially pypa/manylinux2010 + bazel.
-FROM gcr.io/tfx-oss-public/manylinux2014-bazel:bazel-6.1.0
+# Install Bazel 6.5.0
+RUN curl -sSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-x86_64 && \
+    chmod +x /usr/local/bin/bazel
+
+# Install a recent version of cmake
+RUN yum install -y cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+# Set up the environment
+ENV BAZEL_VERSION=6.5.0
+ENV BAZEL_OPTS="--host_jvm_args=-Xms2g --host_jvm_args=-Xmx2g"
+# devtoolset-10 is pre-installed on the image, we just need to enable it.
+ENV PATH="/opt/rh/devtoolset-10/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:${LD_LIBRARY_PATH}"
+
+
 WORKDIR /build
 CMD ["ml_metadata/tools/docker_build/build_manylinux.sh"]


### PR DESCRIPTION
Fix: Update Docker build environment for manylinux

The manylinux build was failing due to an outdated Docker environment.
- The base image had an old GCC, Bazel, and CMake.
- The  dependency was not using the correct compiler.

This change updates the Dockerfile to use a modern
base image with GCC 10 and explicitly installs the required versions
of Bazel and CMake.
It also configures the  build to use the correct toolchain.

This resolves the build failures