### PR TITLE
feat(deprecation): Add ZetaSQL deprecation warning for v1.17.2 patch release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,25 @@
+# Version 1.17.2
+
+## Major Features and Improvements
+
+*   N/A
+
+## Breaking Changes
+
+*   N/A
+
+## Deprecations
+
+*   Deprecate ZetaSQL-based filter_query functionality.
+    The `filter_query` parameter in ListOperationOptions that relies on ZetaSQL for declarative
+    filtering is deprecated and will be removed in version 1.18.0. ZetaSQL
+    dependency is being removed from ML Metadata. Users should migrate to
+    alternative filtering approaches before the 1.18.0 release.
+
+## Bug Fixed and Other Changes
+
+*   N/A
+
 # Version 1.17.1
 
 ## Major Features and Improvements

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,6 +253,7 @@ artifacts = store.get_artifacts()
 # Plus, there are many ways to query the same Artifact
 [stored_data_artifact] = store.get_artifacts_by_id([data_artifact_id])
 artifacts_with_uri = store.get_artifacts_by_uri(data_artifact.uri)
+# Note: filter_query is deprecated and will be removed in version 1.18.0.
 artifacts_with_conditions = store.get_artifacts(
       list_options=mlmd.ListOptions(
           filter_query='uri LIKE "%/data" AND properties.day.int_value > 0'))
@@ -270,6 +271,7 @@ trainer_run.properties["state"].string_value = "RUNNING"
 # Query all registered Execution
 executions = store.get_executions_by_id([run_id])
 # Similarly, the same execution can be queried with conditions.
+# Note: filter_query is deprecated and will be removed in version 1.18.0.
 executions_with_conditions = store.get_executions(
     list_options = mlmd.ListOptions(
         filter_query='type = "Trainer" AND properties.state.string_value IS NOT NULL'))
@@ -355,6 +357,7 @@ experiment_executions = store.get_executions_by_context(experiment_id)
 
 # You can also use neighborhood queries to fetch these artifacts and executions
 # with conditions.
+# Note: filter_query is deprecated and will be removed in version 1.18.0.
 experiment_artifacts_with_conditions = store.get_artifacts(
     list_options = mlmd.ListOptions(
         filter_query=('contexts_a.type = "Experiment" AND contexts_a.name = "exp1"')))

--- a/ml_metadata/metadata_store/metadata_store.py
+++ b/ml_metadata/metadata_store/metadata_store.py
@@ -81,9 +81,13 @@ class ListOptions:
     is_asc: Specifies `order_by` is ascending or descending. If `order_by` is
       not given, the field is ignored. If `order_by` is set, then by default
       ascending order is used for performance benefit.
-    filter_query: An optional boolean expression in SQL syntax to specify
-      conditions on node attributes and directly connected assets. See
-      https://github.com/google/ml-metadata/blob/master/ml_metadata/proto/metadata_store.proto#L705-L783 for the query capabilities and syntax.
+    filter_query: DEPRECATED (will be removed in v1.18.0) - An optional boolean
+      expression in SQL syntax to specify conditions on node attributes and
+      directly connected assets. This feature depends on ZetaSQL which is being
+      removed from ML Metadata. Please migrate to alternative filtering approaches
+      before version 1.18.0. See
+      https://github.com/google/ml-metadata/blob/master/ml_metadata/proto/metadata_store.proto#L705-L783
+      for the query capabilities and syntax.
   """
 
   limit: Optional[int] = None
@@ -1478,6 +1482,16 @@ class MetadataStore:
       if list_options.order_by:
         request.options.order_by_field.field = list_options.order_by.value
       if list_options.filter_query:
+        # DEPRECATED: ZetaSQL-based filter_query will be removed in v1.18.0
+        import warnings
+        warnings.warn(
+            'DEPRECATION WARNING: filter_query is deprecated and will be '
+            'removed in version 1.18.0. This feature depends on ZetaSQL '
+            'which is being removed from ML Metadata. Please migrate to '
+            'alternative filtering approaches before the 1.18.0 release.',
+            DeprecationWarning,
+            stacklevel=3
+        )
         request.options.filter_query = list_options.filter_query
 
     result = []

--- a/ml_metadata/metadata_store/postgresql_query_executor.cc
+++ b/ml_metadata/metadata_store/postgresql_query_executor.cc
@@ -885,6 +885,12 @@ absl::Status PostgreSQLQueryExecutor::ListNodeIDsUsingOptions(
   }
 
   if (options.has_filter_query() && !options.filter_query().empty()) {
+    // DEPRECATED: ZetaSQL-based filter_query is deprecated and will be removed
+    // in version 1.18.0. This feature depends on ZetaSQL which is being phased
+    // out. Please migrate to alternative filtering approaches.
+    LOG(WARNING) << "DEPRECATION WARNING: ZetaSQL-based filter_query is "
+                 << "deprecated and will be removed in version 1.18.0. "
+                 << "This feature depends on ZetaSQL which is being removed.";
     node_table_alias = ml_metadata::FilterQueryBuilder<Node>::kBaseTableAlias;
     ml_metadata::FilterQueryAstResolver<Node> ast_resolver(
         options.filter_query());

--- a/ml_metadata/metadata_store/query_config_executor.cc
+++ b/ml_metadata/metadata_store/query_config_executor.cc
@@ -826,6 +826,12 @@ absl::Status QueryConfigExecutor::ListNodeIDsUsingOptions(
   }
 
   if (options.has_filter_query() && !options.filter_query().empty()) {
+    // DEPRECATED: ZetaSQL-based filter_query is deprecated and will be removed
+    // in version 1.18.0. This feature depends on ZetaSQL which is being phased
+    // out. Please migrate to alternative filtering approaches.
+    LOG(WARNING) << "DEPRECATION WARNING: ZetaSQL-based filter_query is "
+                 << "deprecated and will be removed in version 1.18.0. "
+                 << "This feature depends on ZetaSQL which is being removed.";
     node_table_alias = ml_metadata::FilterQueryBuilder<Node>::kBaseTableAlias;
     ml_metadata::FilterQueryAstResolver<Node> ast_resolver(
         options.filter_query());

--- a/ml_metadata/query/filter_query_ast_resolver.cc
+++ b/ml_metadata/query/filter_query_ast_resolver.cc
@@ -12,6 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
+// DEPRECATED: This file and its associated ZetaSQL-based filter_query
+// functionality is deprecated and will be removed in version 1.18.0.
+// ZetaSQL dependency is being phased out from ML Metadata.
+// Please migrate to alternative filtering approaches.
+
 #include "ml_metadata/query/filter_query_ast_resolver.h"
 #include <vector>
 

--- a/ml_metadata/query/filter_query_ast_resolver.h
+++ b/ml_metadata/query/filter_query_ast_resolver.h
@@ -22,6 +22,11 @@ limitations under the License.
 
 namespace ml_metadata {
 
+// DEPRECATED: This class and its associated ZetaSQL-based filter_query
+// functionality is deprecated and will be removed in version 1.18.0.
+// ZetaSQL dependency is being phased out from ML Metadata.
+// Please migrate to alternative filtering approaches.
+//
 // FilterQueryAstResolver parses the MLMD filtering query string and generates
 // an AST via ZetaSQL analyzer. It can be instantiated with MLMD nodes types:
 // Artifact, Execution and Context.

--- a/ml_metadata/query/filter_query_builder.cc
+++ b/ml_metadata/query/filter_query_builder.cc
@@ -12,6 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
+// DEPRECATED: This file and its associated ZetaSQL-based filter_query
+// functionality is deprecated and will be removed in version 1.18.0.
+// ZetaSQL dependency is being phased out from ML Metadata.
+// Please migrate to alternative filtering approaches.
+
 #include "ml_metadata/query/filter_query_builder.h"
 
 #include <glog/logging.h>

--- a/ml_metadata/query/filter_query_builder.h
+++ b/ml_metadata/query/filter_query_builder.h
@@ -21,6 +21,11 @@ limitations under the License.
 
 namespace ml_metadata {
 
+// DEPRECATED: This class and its associated ZetaSQL-based filter_query
+// functionality is deprecated and will be removed in version 1.18.0.
+// ZetaSQL dependency is being phased out from ML Metadata.
+// Please migrate to alternative filtering approaches.
+//
 // FilterQueryBuilder is a ZetaSQL AST Visitor. It walks through a ZetaSQL
 // boolean expression AST parsed from a filtering query string and generates
 // FROM clauses and WHERE clauses which can be used by MLMD query executors. It


### PR DESCRIPTION
This PR adds the deprecation warning for the ZetaSQL-based `filter_query` functionality.

This change was originally intended for the `v1.17.1` release but was inadvertently missed during the manual cherry-picking process. To ensure users receive adequate notice before the feature is removed in `v1.18.0`, this PR targets the `r1.17` branch to facilitate a new patch release, `v1.17.2`.

The changes in this PR are directly adapted from the deprecation work in [#226](https://github.com/google/ml-metadata/pull/226).

### Changes

- **Python API**: A `DeprecationWarning` is now raised when `ListOptions.filter_query` is used in `get_artifacts`, `get_executions`, or `get_contexts`.
- **C++ Backend**: A `LOG(WARNING)` is now emitted in the C++ query executors when a `filter_query` is processed.
- **Documentation**: The `RELEASE.md` file, and docstrings have been updated to clearly state that `filter_query` is deprecated and will be removed in v1.18.0.
- **Testing**: Python tests have been updated to verify that the `DeprecationWarning` is correctly raised.