### PR TITLE
Remove python 2 init symbols to get compilation to work on 3.12.4

### DIFF
--- a/ml_metadata/ml_metadata.bzl
+++ b/ml_metadata/ml_metadata.bzl
@@ -221,11 +221,9 @@ def ml_metadata_pybind_extension(
         "PyInit_%s" % sname,
     ]
 
-    # For Linux, include Python 2 symbols for compatibility
+    # For Linux, do not include Python 2 symbols for compatibility
     # (version script allows undefined symbols)
     exported_symbols_linux = [
-        "init%s" % sname,
-        "init_%s" % sname,
         "PyInit_%s" % sname,
     ]
 


### PR DESCRIPTION
Stricter llvm linker was not allowing ml-metadata compilation to succeed.

Background: I'm trying to get TFX running on a more modern python, specifically 3.12.4, and this is a fix that unblocks the building of ml-metadata in my environment.  Open to any suggestions about better ways to do this.  The underlying error that this resolves in my environment is below:

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: version script assignment of 'global' to symbol 'initmetadata_store_extension' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'init_metadata_store_extension' failed: symbol not defined
collect2: error: ld returned 1 exit status
Target //ml_metadata:move_generated_files failed to build
```