### PR TITLE
Remove python 2 symbols, part of attempt at porting TFX to 3.12.4

### DIFF
--- a/ml_metadata/ml_metadata.bzl
+++ b/ml_metadata/ml_metadata.bzl
@@ -221,7 +221,7 @@ def ml_metadata_pybind_extension(
         "PyInit_%s" % sname,
     ]
 
-    # For Linux, include Python 2 symbols for compatibility
+    # For Linux, do not include Python 2 symbols for compatibility
     # (version script allows undefined symbols)
     exported_symbols_linux = [
         "PyInit_%s" % sname,

--- a/ml_metadata/ml_metadata.bzl
+++ b/ml_metadata/ml_metadata.bzl
@@ -224,8 +224,6 @@ def ml_metadata_pybind_extension(
     # For Linux, include Python 2 symbols for compatibility
     # (version script allows undefined symbols)
     exported_symbols_linux = [
-        "init%s" % sname,
-        "init_%s" % sname,
         "PyInit_%s" % sname,
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -163,9 +163,9 @@ setup(
     # Make sure to sync the versions of common dependencies (absl-py, numpy,
     # six, and protobuf) with TF.
     install_requires=[
-        'absl-py>=0.9,<2.0.0',
-        'attrs>=20.3,<24',
-        'grpcio>=1.8.6,<2',
+        'absl-py>=0.9,<2.3.2',
+        'attrs>=20.3,<25.5',
+        'grpcio>=1.8.6,<1.66',
         f'protobuf>={"4.25.2" if _IS_PY311 else "4.21.6"},<5',
         'six>=1.10,<2',
     ],


### PR DESCRIPTION
Update versions so that dependencies related to porting TFX to 3.12.4 are addressed. Looking forward to any feedback/changes and discussion.