### PR TITLE
Raise the aarch64 assembler baseline so Abseil can build

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile
+++ b/ml_metadata/tools/docker_server/Dockerfile
@@ -51,7 +51,18 @@ ADD . /mlmd-src
 WORKDIR /mlmd-src
 
 # "-std=c++17" is needed in order to build with ZetaSQL.
-RUN bazel build -c opt --action_env=PATH \
+# Abseil's stacktrace.cc emits the ARMv8.3 pointer-authentication instruction
+# xpaclri, which the assembler rejects at the default armv8-a baseline. The
+# flag is only valid on aarch64, so it is selected by architecture. Note both
+# --copt and --host_copt are needed: the failing target is built in the exec
+# configuration, which --copt does not affect.
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "arm64" ]; then \
+      MARCH_FLAGS="--copt=-march=armv8.3-a --host_copt=-march=armv8.3-a"; \
+    else \
+      MARCH_FLAGS=""; \
+    fi && \
+    bazel build -c opt --action_env=PATH $MARCH_FLAGS \
   --define=grpc_no_ares=true \
   //ml_metadata/metadata_store:metadata_store_server --cxxopt="-std=c++17"
 

--- a/ml_metadata/tools/docker_server/Dockerfile
+++ b/ml_metadata/tools/docker_server/Dockerfile
@@ -40,13 +40,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 ENV BAZEL_VERSION 7.7.0
 WORKDIR /
 RUN mkdir /bazel && \
-    cd /bazel && \
-    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
-    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
-    chmod +x bazel-*.sh && \
-    ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
-    cd / && \
-    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+    ARCH=$(dpkg --print-architecture) && \
+    curl -H "User-Agent: Mozilla/5.0" -fSsL -o /usr/local/bin/bazel \
+      https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-linux-${ARCH} && \
+    curl -H "User-Agent: Mozilla/5.0" -fSsL -o /bazel/LICENSE.txt \
+      https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
+    chmod +x /usr/local/bin/bazel
 
 ADD . /mlmd-src
 WORKDIR /mlmd-src


### PR DESCRIPTION
Follow-up to #247, which I offered there. **This PR is stacked on #247** — please merge that one first, or I can rebase this onto master if you prefer them independent.

Together the two changes make `ml_metadata_store_server` build on `linux/arm64`.

## Problem

With #247 applied, Bazel installs and runs on aarch64, but the build then fails in Abseil. `absl/debugging/stacktrace.cc` emits `xpaclri`, an ARMv8.3 pointer-authentication instruction, which GNU as rejects at the default `armv8-a` baseline:

```
external/abseil-cpp/absl/debugging/stacktrace.cc [for tool] failed
/tmp/ccRV18O3.s:166: Error: selected processor does not support `xpaclri'
/tmp/ccRV18O3.s:386: Error: selected processor does not support `xpaclri'
```

## Change

Pass `-march=armv8.3-a` when the build architecture is arm64, selected from `dpkg --print-architecture`. The flag is invalid on x86_64, so those builds are untouched.

**`--host_copt` is required in addition to `--copt`.** The failing target is compiled `[for tool]`, i.e. in the exec configuration, which `--copt` does not affect. With `--copt` alone the error is byte-identical, which makes it look as though the flag had no effect — that cost me a build cycle, so it seemed worth a comment in the Dockerfile.

## A caveat I would rather flag than hide

`-march=armv8-a+pauth` would be the better choice. `xpaclri` is in HINT space and a no-op on cores without pointer authentication, so `+pauth` keeps ARMv8.0 compatibility, whereas `armv8.3-a` raises the baseline and makes the binary require ARMv8.3 hardware — Graviton2, for instance, is ARMv8.2.

GCC 9 on the `ubuntu:20.04` builder rejects it:

```
cc1: error: invalid feature modifier 'pauth' in '-march=armv8-a+pauth'
```

So the cleaner long-term fix is a newer builder base image, after which this could become `+pauth` or drop away entirely. I did not want to bundle a base-image bump into this PR unasked — happy to do it if you would prefer that route.

## Verification

On master (`be943b8`) with #247 applied, on an aarch64 host (NVIDIA GB10, Ubuntu 24.04):

```
$ docker image inspect ... --format '{{.Architecture}}'
arm64                                    (131 MB)

$ docker run --entrypoint /bin/metadata_store_server ... --help
metadata_store_server: Warning: SetUsageMessage() never called
  Flags from external/com_github_gflags_gflags/src/gflags.cc: ...
```

The full C++ tree — ZetaSQL, gRPC, libmysqlclient, PostgreSQL — compiles with zero errors.

I have not rebuilt on x86_64 to confirm no regression there; the flag is gated behind the arch check, so x86_64 takes the same code path as before, but your CI would confirm that properly.

Context: this unblocks Kubeflow Pipelines on ARM, tracked in kubeflow/pipelines#10308 and kubeflow/pipelines#13957.
